### PR TITLE
Fix `DocLink` styles

### DIFF
--- a/src/components/DocLink.tsx
+++ b/src/components/DocLink.tsx
@@ -53,10 +53,9 @@ const DocLink: React.FC<IProps> = ({ to, children, isExternal = false }) => {
             _hover={{ textDecoration: "none" }}
             hideArrow
           >
-            {/* FIX: this Text is causing rendering issues */}
-            {/* <Text color="text300" fontWeight="semibold" margin={0}> */}
-            {children}
-            {/* </Text> */}
+            <Text color="text300" fontWeight="semibold" margin={0}>
+              {children}
+            </Text>
           </LinkOverlay>
         </Box>
         <Icon


### PR DESCRIPTION
## Description

Reverted a previously conflicted style from the `DocLink` component that was solved in the [downgrade of mdx](https://github.com/ethereum/ethereum-org-fork/pull/18).

## Related Issue

#9
