### PR TITLE
Fix css property casing

### DIFF
--- a/src/@chakra-ui/styles.ts
+++ b/src/@chakra-ui/styles.ts
@@ -57,7 +57,7 @@ const styles = {
       marginBottom: "0",
     },
     "p *:last-child": {
-      "margin-bottom": "0",
+      marginBottom: "0",
     },
     "li > p": {
       marginBottom: "calc(1.45rem / 2)",


### PR DESCRIPTION
## Description
Fixes warning: "Using kebab-case for css properties in objects is not supported. Did you mean marginBottom?"
