### PR TITLE
fix: `getLastModifiedDate`

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,9 +1,7 @@
 import i18nConfig from "../../i18n.config.json"
 
 export const CONTENT_DIR = "public/content"
-export const OLD_CONTENT_DIR = "src/content"
 export const TRANSLATIONS_DIR = "public/content/translations"
-export const OLD_TRANSLATIONS_DIR = "src/content/translations"
 
 // i18n
 export const DEFAULT_LOCALE = "en"

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -1,28 +1,33 @@
+import fs from "fs"
 import { join } from "path"
+import { execSync } from "child_process"
 
-import { LAST_COMMIT_BASE_URL, OLD_CONTENT_DIR } from "../constants"
+import { CONTENT_DIR, DEFAULT_LOCALE, TRANSLATIONS_DIR } from "../constants"
 
-export const getLastModifiedDate = async (filePath: string, locale: string) => {
-  const headers = new Headers({
-    // About personal access tokens https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#about-personal-access-tokens
-    Authorization: "Token " + process.env.GITHUB_TOKEN_READ_ONLY,
-  })
-  const url = new URL(LAST_COMMIT_BASE_URL)
-  // TODO: swap `OLD_CONTENT_DIR` for new `CONTENT_DIR` constant value before deploying site to prod
-  // as we're currently fetching last commit date from canonical repo
+// This util filters the git log to get the file last commit info, and then the commit date (last update)
+export const getLastModifiedDate = async (slug: string, locale: string) => {
+  const translatedContentPath = join(TRANSLATIONS_DIR, locale, slug, "index.md")
+  const contentIsNotTranslated = !fs.existsSync(translatedContentPath)
+  let filePath = ""
 
-  // Get last commit date (last update) from english version only to avoid hitting API rate limit
-  // See https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting
-  url.searchParams.set("path", join(OLD_CONTENT_DIR, filePath, "index.md"))
-  url.searchParams.set("page", "1")
-  url.searchParams.set("per_page", "1")
-
-  try {
-    const response = await fetch(url, { headers })
-    const commits = await response.json()
-
-    return commits[0].commit.committer.date
-  } catch (err) {
-    console.error(filePath, err)
+  if (locale === DEFAULT_LOCALE || contentIsNotTranslated) {
+    // Use git log data from english content
+    filePath = join(CONTENT_DIR, slug, "index.md")
+  } else {
+    // Use git log data from translated content
+    filePath = join(TRANSLATIONS_DIR, locale, slug, "index.md")
   }
+
+  // git command to show file last commit info
+  const gitCommand = `git log -1 -- ${filePath}`
+  // Execute git command and parse result to string
+  const logInfo = execSync(gitCommand).toString()
+  // Filter commit date in log and return date using ISOString format (same that GH API uses)
+  const lasCommitDate = logInfo
+    .split("\n")
+    .filter((x) => x.startsWith("Date: "))[0]
+    .slice("Date:".length)
+    .trim()
+
+  return new Date(lasCommitDate).toISOString()
 }


### PR DESCRIPTION
Because of the number of builds we've been triggering, we've been hitting the gh rate limits, which is 5k API requests per hour (https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting). Because of that, and how `getLastModifiedDate` works, which is fetching the last file commit date from gh API,  the fetch the data from the git log instead.

This PR updates `getLastModifiedDate` util to get the file (including translations) last commit date locally, without sending a request to GH API and removes redundant constants not used anymore.

## Previews

- https://deploy-preview-51--ethereum-org-fork.netlify.app/en/bridges (original)
- https://deploy-preview-51--ethereum-org-fork.netlify.app/es/bridges (translation)