### PR TITLE
i18n: Link & Breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -6,6 +6,7 @@ import {
   BreadcrumbLink,
   BreadcrumbProps,
 } from "@chakra-ui/react"
+import { useRouter } from "next/router"
 
 import { BaseLink } from "../Link"
 
@@ -39,13 +40,10 @@ const Breadcrumbs: React.FC<IProps> = ({
 }) => {
   // TODO: update when i18n is set up
   // const { t } = useTranslation()
-  // const { language } = useI18next()
-  const language = "en"
+  const { locale } = useRouter()
 
-  // TODO: update when i18n is set up
-  // const hasHome = originalSlug.includes(`/${language}/`)
   const hasHome = true
-  const slug = originalSlug.replace(`/${language}/`, "/")
+  const slug = originalSlug.replace(`/${locale}/`, "/")
 
   const slugChunk = slug.split("/")
   const sliced = slugChunk.filter((item) => !!item)

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -42,9 +42,8 @@ const Breadcrumbs: React.FC<IProps> = ({
   // const { t } = useTranslation()
   const { locale } = useRouter()
 
-  const hasHome = true
+  const hasHome = originalSlug.includes(`/${locale}/`)
   const slug = originalSlug.replace(`/${locale}/`, "/")
-
   const slugChunk = slug.split("/")
   const sliced = slugChunk.filter((item) => !!item)
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -61,7 +61,7 @@ export const BaseLink: LinkComponent = forwardRef(function Link(props, ref) {
 
   let href = (to ?? hrefProp)!
 
-  const { asPath } = useRouter()
+  const { asPath, locale } = useRouter()
   const isActive = url.isHrefActive(href, asPath, isPartiallyActive)
 
   const isDiscordInvite = url.isDiscordInvite(href)
@@ -103,11 +103,17 @@ export const BaseLink: LinkComponent = forwardRef(function Link(props, ref) {
     )
   }
 
-  return <NextLink {...commonProps}>{children}</NextLink>
+  return (
+    <NextLink locale={locale} {...commonProps}>
+      {children}
+    </NextLink>
+  )
 })
 
-const InlineLink: FC<LinkProps> = forwardRef((props, ref) => (
-  <BaseLink data-inline-link ref={ref} {...props} />
-))
+const InlineLink: FC<LinkProps> = forwardRef((props, ref) => {
+  const { locale } = useRouter()
+
+  return <BaseLink data-inline-link ref={ref} locale={locale} {...props} />
+})
 
 export default InlineLink

--- a/src/layouts/Roadmap.tsx
+++ b/src/layouts/Roadmap.tsx
@@ -102,7 +102,12 @@ export const roadmapComponents = {
 }
 
 interface IProps extends PageContent, ChildOnlyProp {}
-export const RoadmapLayout: React.FC<IProps> = ({ children, frontmatter, slug, tocItems }) => {
+export const RoadmapLayout: React.FC<IProps> = ({
+  children,
+  frontmatter,
+  slug,
+  tocItems,
+}) => {
   const isRightToLeft = isLangRightToLeft(frontmatter.lang as Lang)
 
   const dropdownLinks: ButtonDropdownList = {
@@ -163,8 +168,7 @@ export const RoadmapLayout: React.FC<IProps> = ({ children, frontmatter, slug, t
         <Flex w="100%" flexDirection={{ base: "column", md: "row" }}>
           <TitleCard>
             {/* TODO: Double check this slug works */}
-            <Breadcrumbs slug={slug} />{" "}
-            <Title>{frontmatter.title}</Title>
+            <Breadcrumbs slug={slug} /> <Title>{frontmatter.title}</Title>
             <OldText>{frontmatter.description}</OldText>
             {frontmatter?.buttons && (
               // FIXME: remove the `ul` override once removed the corresponding
@@ -173,24 +177,16 @@ export const RoadmapLayout: React.FC<IProps> = ({ children, frontmatter, slug, t
                 {frontmatter.buttons.map((button, idx) => {
                   if (button?.to) {
                     return (
-                      <WrapItem>
-                        <ButtonLink
-                          key={idx}
-                          variant={button?.variant}
-                          to={button?.to}
-                        >
+                      <WrapItem key={idx}>
+                        <ButtonLink variant={button?.variant} to={button?.to}>
                           {button.label}
                         </ButtonLink>
                       </WrapItem>
                     )
                   }
                   return (
-                    <WrapItem>
-                      <Button
-                        key={idx}
-                        variant={button?.variant}
-                        toId={button?.toId}
-                      >
+                    <WrapItem key={idx}>
+                      <Button variant={button?.variant} toId={button?.toId}>
                         {button?.label}
                       </Button>
                     </WrapItem>


### PR DESCRIPTION
This PR adds the `locale` prop from router to `Link` and `Breadcrumbs` components for localized navigation between internal pages
