### PR TITLE
i18n: TranslationBanner & TranslationBannerLegal

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,14 +12,16 @@ import {
 // import { useI18next, useTranslation } from "gatsby-plugin-react-i18next"
 import React from "react"
 import { FaDiscord, FaGithub, FaTwitter } from "react-icons/fa"
+import { useRouter } from "next/router"
+
+import { BaseLink } from "./Link"
 
 // TODO
-// import { Lang } from "../utils/languages"
 // import { getLocaleTimestamp } from "../utils/time"
-// import { isLangRightToLeft } from "../utils/translations"
+import { isLangRightToLeft } from "@/lib/utils/translations"
 
-import { TranslationKey } from "@/lib/types"
-import { BaseLink } from "./Link"
+import { Lang, TranslationKey } from "@/lib/types"
+
 // TODO
 // import Translation from "./Translation"
 
@@ -55,15 +57,13 @@ export interface LinkSection {
 export interface IProps {}
 
 const Footer: React.FC<IProps> = () => {
-  // const { language } = useI18next()
+  const { locale } = useRouter()
+  // TODO: enable after setting i18n UI strings
   // const { t } = useTranslation()
 
-  // TODO
-  // const isPageRightToLeft = isLangRightToLeft(language as Lang)
-  const isPageRightToLeft = false
-
+  const isPageRightToLeft = isLangRightToLeft(locale as Lang)
+  // TODO: check if `medBp` is being used or remove it
   const [medBp] = useToken("breakpoints", ["md"])
-
   const linkSections: Array<LinkSection> = [
     {
       title: "Use Ethereum", // t("use-ethereum"),

--- a/src/components/TranslationBanner.tsx
+++ b/src/components/TranslationBanner.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react"
-import { useRouter } from "next/router"
 
 import { Box, CloseButton, Flex, Heading, useToken } from "@chakra-ui/react"
 import { ButtonLink } from "./Buttons"
 // import Translation from "./Translation"
 import Emoji from "./Emoji"
+
+import { DEFAULT_LOCALE } from "../lib/constants"
 
 export interface IProps {
   shouldShow: boolean
@@ -21,7 +22,6 @@ const TranslationBanner: React.FC<IProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(shouldShow)
   const [textColor] = useToken("colors", ["text"])
-  const { locale } = useRouter()
 
   useEffect(() => {
     setIsOpen(shouldShow)
@@ -111,7 +111,7 @@ const TranslationBanner: React.FC<IProps> = ({
                   mt={{ base: 2, sm: 0 }}
                   borderColor="#333333"
                   color="#333333"
-                  lang={locale}
+                  lang={DEFAULT_LOCALE}
                 >
                   {/* TODO: enable after setting i18n UI strings */}
                   {/* <Translation id="translation-banner-button-see-english" /> */}

--- a/src/components/TranslationBanner.tsx
+++ b/src/components/TranslationBanner.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from "react"
+import { useRouter } from "next/router"
 
 import { Box, CloseButton, Flex, Heading, useToken } from "@chakra-ui/react"
 import { ButtonLink } from "./Buttons"
-import Translation from "./Translation"
+// import Translation from "./Translation"
 import Emoji from "./Emoji"
-
-import { DEFAULT_LOCALE } from "../lib/constants"
 
 export interface IProps {
   shouldShow: boolean
@@ -22,6 +21,7 @@ const TranslationBanner: React.FC<IProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(shouldShow)
   const [textColor] = useToken("colors", ["text"])
+  const { locale } = useRouter()
 
   useEffect(() => {
     setIsOpen(shouldShow)
@@ -75,7 +75,9 @@ const TranslationBanner: React.FC<IProps> = ({
               lineHeight="100%"
               my="0"
             >
-              <Translation id={headerTextId} />
+              {/* TODO: enable after setting i18n UI strings */}
+              {/* <Translation id={headerTextId} /> */}
+              {headerTextId}
             </Heading>
             <Emoji
               text=":globe_showing_asia_australia:"
@@ -85,7 +87,9 @@ const TranslationBanner: React.FC<IProps> = ({
             />
           </Flex>
           <p>
-            <Translation id={bodyTextId} />
+            {/* TODO: enable after setting i18n UI strings */}
+            {/* <Translation id={bodyTextId} /> */}
+            {bodyTextId}
           </p>
           <Flex
             align={{ base: "flex-start", sm: "center" }}
@@ -93,7 +97,9 @@ const TranslationBanner: React.FC<IProps> = ({
           >
             <Box>
               <ButtonLink to="/contributing/translation-program/">
-                <Translation id="translation-banner-button-translate-page" />
+                {/* TODO: enable after setting i18n UI strings */}
+                {/* <Translation id="translation-banner-button-translate-page" /> */}
+                translation-banner-button-translate-page
               </ButtonLink>
             </Box>
             {!isPageContentEnglish && (
@@ -105,9 +111,11 @@ const TranslationBanner: React.FC<IProps> = ({
                   mt={{ base: 2, sm: 0 }}
                   borderColor="#333333"
                   color="#333333"
-                  language={DEFAULT_LOCALE}
+                  lang={locale}
                 >
-                  <Translation id="translation-banner-button-see-english" />
+                  {/* TODO: enable after setting i18n UI strings */}
+                  {/* <Translation id="translation-banner-button-see-english" /> */}
+                  translation-banner-button-see-english
                 </ButtonLink>
               </Box>
             )}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,17 +1,65 @@
 import { Container } from "@chakra-ui/react"
+import { useRouter } from "next/router"
+import { join } from "path"
 
 import Nav from "@/components/Nav"
 import Footer from "@/components/Footer"
+import TranslationBanner from "@/components/TranslationBanner"
+import TranslationBannerLegal from "@/components/TranslationBannerLegal"
+
+import { isLangRightToLeft } from "@/lib/utils/translations"
+
+import { Lang } from "@/lib/types"
+
+import { DEFAULT_LOCALE } from "@/lib/constants"
 
 import { lightTheme as oldTheme } from "../theme"
 
-export const RootLayout = ({ children }) => (
-  <Container mx="auto" maxW={oldTheme.variables.maxPageWidth}>
-    {/* TODO: get proper path value after setting i18n */}
-    <Nav path="" />
+export const RootLayout = ({
+  children,
+  contentIsOutdated,
+  contentNotTranslated,
+}) => {
+  const { locale, asPath } = useRouter()
 
-    {children}
+  const isLegal =
+    asPath.includes(`/cookie-policy/`) ||
+    asPath.includes(`/privacy-policy/`) ||
+    asPath.includes(`/terms-of-use/`) ||
+    asPath.includes(`/contributing/`) ||
+    asPath.includes(`/style-guide/`)
 
-    <Footer />
-  </Container>
-)
+  const isPageTranslationOutdated = contentIsOutdated ?? false
+  const isPageContentEnglish = contentNotTranslated
+  const isPageLanguageEnglish = locale === DEFAULT_LOCALE
+  const shouldShowTranslationBanner =
+    (isPageTranslationOutdated ||
+      (isPageContentEnglish && !isPageLanguageEnglish)) &&
+    !isLegal
+  const isPageRightToLeft = isLangRightToLeft(locale as Lang)
+  const originalPagePath = join(DEFAULT_LOCALE, asPath)
+
+  return (
+    <Container mx="auto" maxW={oldTheme.variables.maxPageWidth}>
+      {/* TODO: get proper path value after setting i18n */}
+      <Nav path="" />
+
+      <TranslationBanner
+        shouldShow={shouldShowTranslationBanner}
+        isPageContentEnglish={isPageContentEnglish}
+        isPageRightToLeft={isPageRightToLeft}
+        originalPagePath={originalPagePath}
+      />
+
+      <TranslationBannerLegal
+        shouldShow={isLegal}
+        isPageRightToLeft={isPageRightToLeft}
+        originalPagePath={originalPagePath}
+      />
+
+      {children}
+
+      <Footer />
+    </Container>
+  )
+}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -10,6 +10,7 @@ import TranslationBannerLegal from "@/components/TranslationBannerLegal"
 import { isLangRightToLeft } from "@/lib/utils/translations"
 
 import { Lang } from "@/lib/types"
+import { Root } from "@/lib/interfaces"
 
 import { DEFAULT_LOCALE } from "@/lib/constants"
 
@@ -19,7 +20,7 @@ export const RootLayout = ({
   children,
   contentIsOutdated,
   contentNotTranslated,
-}) => {
+}: Root) => {
   const { locale, asPath } = useRouter()
 
   const isLegal =
@@ -30,11 +31,10 @@ export const RootLayout = ({
     asPath.includes(`/style-guide/`)
 
   const isPageTranslationOutdated = contentIsOutdated ?? false
-  const isPageContentEnglish = contentNotTranslated
   const isPageLanguageEnglish = locale === DEFAULT_LOCALE
   const shouldShowTranslationBanner =
     (isPageTranslationOutdated ||
-      (isPageContentEnglish && !isPageLanguageEnglish)) &&
+      (contentNotTranslated && !isPageLanguageEnglish)) &&
     !isLegal
   const isPageRightToLeft = isLangRightToLeft(locale as Lang)
   const originalPagePath = join(DEFAULT_LOCALE, asPath)
@@ -46,7 +46,7 @@ export const RootLayout = ({
 
       <TranslationBanner
         shouldShow={shouldShowTranslationBanner}
-        isPageContentEnglish={isPageContentEnglish}
+        isPageContentEnglish={contentNotTranslated}
         isPageRightToLeft={isPageRightToLeft}
         originalPagePath={originalPagePath}
       />

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -62,6 +62,7 @@ export interface PageContent {
   frontmatter: Frontmatter
   tocItems: Array<ToCItem>
   lastUpdatedDate?: string
+  contentNotTranslated: boolean
 }
 
 export interface RequiredFrontmatter {

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -56,6 +56,13 @@ export interface ToCItem {
 /**
  * Layout interface
  */
+
+export interface Root {
+  children: JSX.Element
+  contentIsOutdated: boolean
+  contentNotTranslated: boolean
+}
+
 export interface PageContent {
   slug: string
   content: string

--- a/src/lib/utils/md.ts
+++ b/src/lib/utils/md.ts
@@ -101,10 +101,12 @@ export const getContentBySlug = (slug: string) => {
   }
 
   let fullPath = join(CURRENT_CONTENT_DIR, realSlug)
+  let contentNotTranslated = false
 
   // If content is not translated, use english content fallback
   if (!fs.existsSync(fullPath)) {
     fullPath = getFallbackEnglishPath(fullPath)
+    contentNotTranslated = true
   }
 
   const fileContents = fs.readFileSync(fullPath, "utf8")
@@ -115,6 +117,7 @@ export const getContentBySlug = (slug: string) => {
     content,
     frontmatter,
     tocItems: generateTableOfContents(content),
+    contentNotTranslated,
   }
 
   return items

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -98,6 +98,7 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (
   const markdown = getContentBySlug(`${locale}/${params.slug.join("/")}`)
   const frontmatter = markdown.frontmatter
   const tocItems = markdown.tocItems
+  const contentNotTranslated = markdown.contentNotTranslated
 
   const mdPath = join("/content", ...params.slug)
   const mdDir = join("public", mdPath)
@@ -129,6 +130,7 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (
       originalSlug,
       frontmatter,
       lastUpdatedDate,
+      contentNotTranslated,
       layout,
       tocItems,
     },
@@ -155,18 +157,23 @@ const ContentPage: NextPageWithLayout<ContentPageProps> = ({
 
 // Per-Page Layouts: https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#with-typescript
 ContentPage.getLayout = (page: ReactElement) => {
-  // `slug`, `frontmatter`, `lastUpdatedDate` and `layout` values are returned by `getStaticProps` method and passed to the page component
+  // values returned by `getStaticProps` method and passed to the page component
   const {
     originalSlug: slug,
     frontmatter,
     lastUpdatedDate,
+    contentNotTranslated,
     layout,
     tocItems,
   } = page.props
   const layoutProps = { slug, frontmatter, lastUpdatedDate, tocItems }
   const Layout = layoutMapping[layout]
+
   return (
-    <RootLayout>
+    <RootLayout
+      contentIsOutdated={frontmatter.isOutdated}
+      contentNotTranslated={contentNotTranslated}
+    >
       <Layout {...layoutProps}>{page}</Layout>
     </RootLayout>
   )

--- a/src/pages/developers/tutorials/[...tutorial].tsx
+++ b/src/pages/developers/tutorials/[...tutorial].tsx
@@ -36,6 +36,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (
   const tutorialPath = path.join(tutorialsPath, params.tutorial.join("/"))
   const markdown = getContentBySlug(tutorialPath)
   const frontmatter = markdown.frontmatter
+  const contentNotTranslated = markdown.contentNotTranslated
   // TODO: see how we can handle the published date on the tutorial's layout
   // since we can't send the Date object anymore
   frontmatter.published = frontmatter.published.toString()
@@ -59,6 +60,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (
       slug: tutorialPath,
       frontmatter,
       lastUpdatedDate,
+      contentNotTranslated,
     },
   }
 }
@@ -75,12 +77,16 @@ const ContentPage: NextPageWithLayout<Props> = ({ mdxSource }) => {
 
 // Per-Page Layouts: https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#with-typescript
 ContentPage.getLayout = (page: ReactElement) => {
-  // `slug`, `frontmatter` and `lastUpdatedDate` values are returned by `getStaticProps` method and passed to the page component
-  const { slug, frontmatter, lastUpdatedDate } = page.props
+  // values returned by `getStaticProps` method and passed to the page component
+  const { slug, frontmatter, lastUpdatedDate, contentNotTranslated } =
+    page.props
   const layoutProps = { slug, frontmatter, lastUpdatedDate }
 
   return (
-    <RootLayout>
+    <RootLayout
+      contentIsOutdated={frontmatter.isOutdated}
+      contentNotTranslated={contentNotTranslated}
+    >
       <TutorialLayout {...layoutProps}>{page}</TutorialLayout>
     </RootLayout>
   )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -159,8 +159,6 @@
     "./src/components/Tag/index.tsx",
     "./src/components/TitleCardList.tsx",
     "./src/components/Translation.tsx",
-    "./src/components/TranslationBanner.tsx",
-    "./src/components/TranslationBannerLegal.tsx",
     "./src/components/TranslationChartImage.tsx",
     "./src/components/TranslationLeaderboard.tsx",
     "./src/components/Trilemma/Triangle.tsx",


### PR DESCRIPTION
This PR adds the `TranslationBanner` & `TranslationBannerLegal` components to `RootLayout` and enables the banners when appropriate

## Previews

- https://deploy-preview-55--ethereum-org-fork.netlify.app/es/about (should not open `TranslationBanner` banner, content is translated)
- https://deploy-preview-55--ethereum-org-fork.netlify.app/es/roadmap/scaling (should open `TranslationBanner` banner, content is not translated)
