### PR TITLE
feat: Last deploy date

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,9 +16,8 @@ import { useRouter } from "next/router"
 
 import { BaseLink } from "./Link"
 
-// TODO
-// import { getLocaleTimestamp } from "../utils/time"
 import { isLangRightToLeft } from "@/lib/utils/translations"
+import { getLocaleTimestamp } from "@/lib/utils/time"
 
 import { Lang, TranslationKey } from "@/lib/types"
 
@@ -54,9 +53,11 @@ export interface LinkSection {
   }>
 }
 
-export interface IProps {}
+export interface IProps {
+  lastDeployDate: string
+}
 
-const Footer: React.FC<IProps> = () => {
+const Footer: React.FC<IProps> = ({ lastDeployDate }) => {
   const { locale } = useRouter()
   // TODO: enable after setting i18n UI strings
   // const { t } = useTranslation()
@@ -305,11 +306,8 @@ const Footer: React.FC<IProps> = () => {
         <Box color="text200">
           {/* TODO */}
           {/* <Translation id="website-last-updated" />:{" "} */}
-          Website last updated: August 17, 2023
-          {/* {getLocaleTimestamp(
-            language as Lang,
-            data.allSiteBuildMetadata.edges[0].node.buildTime
-          )} */}
+          Website last updated:{" "}
+          {getLocaleTimestamp(locale as Lang, lastDeployDate!)}
         </Box>
         <Box my={4}>
           {socialLinks.map((link, idk) => {

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -20,6 +20,7 @@ export const RootLayout = ({
   children,
   contentIsOutdated,
   contentNotTranslated,
+  lastDeployDate,
 }: Root) => {
   const { locale, asPath } = useRouter()
 
@@ -59,7 +60,7 @@ export const RootLayout = ({
 
       {children}
 
-      <Footer />
+      <Footer lastDeployDate={lastDeployDate} />
     </Container>
   )
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,6 +17,8 @@ export const DISCORD_PATH = "/discord/" as const
 export const CONTENT_IMAGES_MAX_WIDTH = 800
 export const LAST_COMMIT_BASE_URL =
   "https://api.github.com/repos/ethereum/ethereum-org-website/commits"
+export const LAST_DEPLOY_BASE_URL =
+  "https://api.github.com/repos/ethereum/ethereum-org-website/pulls?base=master&state=closed"
 
 // Quiz Hub
 export const PROGRESS_BAR_GAP = "4px"

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -140,6 +140,7 @@ export interface Root {
   children: JSX.Element
   contentIsOutdated: boolean
   contentNotTranslated: boolean
+  lastDeployDate: string
 }
 
 export interface MdPageContent {

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -2,7 +2,12 @@ import fs from "fs"
 import { join } from "path"
 import { execSync } from "child_process"
 
-import { CONTENT_DIR, DEFAULT_LOCALE, TRANSLATIONS_DIR } from "../constants"
+import {
+  CONTENT_DIR,
+  DEFAULT_LOCALE,
+  LAST_DEPLOY_BASE_URL,
+  TRANSLATIONS_DIR,
+} from "../constants"
 
 // This util filters the git log to get the file last commit info, and then the commit date (last update)
 export const getLastModifiedDate = async (slug: string, locale: string) => {
@@ -23,11 +28,35 @@ export const getLastModifiedDate = async (slug: string, locale: string) => {
   // Execute git command and parse result to string
   const logInfo = execSync(gitCommand).toString()
   // Filter commit date in log and return date using ISOString format (same that GH API uses)
-  const lasCommitDate = logInfo
+  const lastCommitDate = logInfo
     .split("\n")
     .filter((x) => x.startsWith("Date: "))[0]
     .slice("Date:".length)
     .trim()
 
-  return new Date(lasCommitDate).toISOString()
+  return new Date(lastCommitDate).toISOString()
+}
+
+export const getLastDeployDate = async () => {
+  const headers = new Headers({
+    // About personal access tokens https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#about-personal-access-tokens
+    Authorization: "Token " + process.env.GITHUB_TOKEN_READ_ONLY,
+  })
+
+  try {
+    // Fetch data from closed PRs made to the master branch
+    const response = await fetch(LAST_DEPLOY_BASE_URL, { headers })
+    const pullRequests = await response.json()
+
+    // Get the `merged_at` date (deployment date) from last deploy PR made to the master branch
+    const lastDeployDate: string = pullRequests.filter((pr) =>
+      pr.title.toLowerCase().includes("deploy")
+    )[0].merged_at
+
+    return lastDeployDate
+  } catch (err) {
+    console.error(err)
+    // If API fetch fails, use current date as fallback date
+    return new Date().toISOString()
+  }
 }

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm"
 import { join } from "path"
 
 import { getContent, getContentBySlug } from "@/lib/utils/md"
-import { getLastModifiedDate } from "@/lib/utils/gh"
+import { getLastModifiedDate, getLastDeployDate } from "@/lib/utils/gh"
 import rehypeImg from "@/lib/rehype/rehypeImg"
 import rehypeHeadingIds from "@/lib/rehype/rehypeHeadingIds"
 
@@ -116,6 +116,7 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (
 
   const originalSlug = `/${params.slug.join("/")}/`
   const lastUpdatedDate = await getLastModifiedDate(originalSlug, locale!)
+  const lastDeployDate = await getLastDeployDate()
 
   // Get corresponding layout
   let layout = frontmatter.template
@@ -130,6 +131,7 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (
       originalSlug,
       frontmatter,
       lastUpdatedDate,
+      lastDeployDate,
       contentNotTranslated,
       layout,
       tocItems,
@@ -162,18 +164,22 @@ ContentPage.getLayout = (page: ReactElement) => {
     originalSlug: slug,
     frontmatter,
     lastUpdatedDate,
+    lastDeployDate,
     contentNotTranslated,
     layout,
     tocItems,
   } = page.props
+
+  const rootLayoutProps = {
+    contentIsOutdated: frontmatter.isOutdated,
+    contentNotTranslated,
+    lastDeployDate,
+  }
   const layoutProps = { slug, frontmatter, lastUpdatedDate, tocItems }
   const Layout = layoutMapping[layout]
 
   return (
-    <RootLayout
-      contentIsOutdated={frontmatter.isOutdated}
-      contentNotTranslated={contentNotTranslated}
-    >
+    <RootLayout {...rootLayoutProps}>
       <Layout {...layoutProps}>{page}</Layout>
     </RootLayout>
   )

--- a/src/pages/developers/tutorials/[...tutorial].tsx
+++ b/src/pages/developers/tutorials/[...tutorial].tsx
@@ -7,7 +7,7 @@ import path from "path"
 
 import { getContentBySlug } from "@/lib/utils/md"
 import rehypeImg from "@/lib/rehype/rehypeImg"
-import { getLastModifiedDate } from "@/lib/utils/gh"
+import { getLastDeployDate, getLastModifiedDate } from "@/lib/utils/gh"
 
 // Layouts
 import { RootLayout, TutorialLayout } from "@/layouts"
@@ -54,6 +54,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (
   })
 
   const lastUpdatedDate = await getLastModifiedDate(tutorialPath, locale!)
+  const lastDeployDate = await getLastDeployDate()
 
   return {
     props: {
@@ -61,6 +62,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (
       slug: tutorialPath,
       frontmatter,
       lastUpdatedDate,
+      lastDeployDate,
       contentNotTranslated,
     },
   }
@@ -79,15 +81,23 @@ const ContentPage: NextPageWithLayout<Props> = ({ mdxSource }) => {
 // Per-Page Layouts: https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#with-typescript
 ContentPage.getLayout = (page: ReactElement) => {
   // values returned by `getStaticProps` method and passed to the page component
-  const { slug, frontmatter, lastUpdatedDate, contentNotTranslated } =
-    page.props
+  const {
+    slug,
+    frontmatter,
+    lastUpdatedDate,
+    lastDeployDate,
+    contentNotTranslated,
+  } = page.props
+
+  const rootLayoutProps = {
+    contentIsOutdated: frontmatter.isOutdated,
+    contentNotTranslated,
+    lastDeployDate,
+  }
   const layoutProps = { slug, frontmatter, lastUpdatedDate }
 
   return (
-    <RootLayout
-      contentIsOutdated={frontmatter.isOutdated}
-      contentNotTranslated={contentNotTranslated}
-    >
+    <RootLayout {...rootLayoutProps}>
       <TutorialLayout {...layoutProps}>{page}</TutorialLayout>
     </RootLayout>
   )


### PR DESCRIPTION
This PR adds the `getLastDeployDate` util to fetch the last deploy date from GitHub API and use it in the `Footer` component.

The [base url used to fetch the API](https://api.github.com/repos/ethereum/ethereum-org-website/pulls?base=master&state=closed) filters already closed (merged) PRs made to the master branch.

## Description

- adds `LAST_DEPLOY_BASE_URL` constant
- adds `getLastDeployDate` to `/utils/gh`
- updates `RootLayout` and `Footer` components
- updates `GetStaticProps` in `[...slug]` and `GetServerSideProps` in `[...tutorial]` pages to use `lastDeployDate`