### PR TITLE
Catch empty deploys with fallback value

### DIFF
--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -53,8 +53,8 @@ export const getLastDeployDate = async () => {
       title.toLowerCase().includes("deploy")
     )
 
-    const lastDeployDate: string =
-      deploys.length > 0 ? deploys[0].merged_at : new Date().toISOString()
+    if (deploys.length <= 0) throw new Error("No deploy PRs found")
+    const lastDeployDate: string = deploys[0].merged_at
 
     return lastDeployDate
   } catch (err) {

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -49,9 +49,12 @@ export const getLastDeployDate = async () => {
     const pullRequests = await response.json()
 
     // Get the `merged_at` date (deployment date) from last deploy PR made to the master branch
-    const lastDeployDate: string = pullRequests.filter((pr) =>
-      pr.title.toLowerCase().includes("deploy")
-    )[0].merged_at
+    const deploys = pullRequests.filter(({ title }: { title: string }) =>
+      title.toLowerCase().includes("deploy")
+    )
+
+    const lastDeployDate: string =
+      deploys.length > 0 ? deploys[0].merged_at : new Date().toISOString()
 
     return lastDeployDate
   } catch (err) {


### PR DESCRIPTION
## Description
Adds guarding for empty array in `getLastDeployDate`, throwing an error if empty. This allows handling by `catch` block to log an error and return new date string as fallback.
