### PR TITLE
Autolink images

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -28,7 +28,6 @@ type BaseProps = {
   hideArrow?: boolean
   isPartiallyActive?: boolean
   activeStyle?: StyleProps
-  forceExternal?: boolean
   // customEventOptions?: MatomoEventOptions
   // dir?: Direction // TODO: remove this prop once we use the native Chakra RTL support
 }
@@ -57,7 +56,6 @@ export const BaseLink: LinkComponent = forwardRef(function Link(props, ref) {
     hideArrow,
     isPartiallyActive = true,
     activeStyle = { color: "primary.base" },
-    forceExternal,
     ...rest
   } = props
 
@@ -68,7 +66,7 @@ export const BaseLink: LinkComponent = forwardRef(function Link(props, ref) {
 
   const isDiscordInvite = url.isDiscordInvite(href)
   const isPdf = url.isPdf(href)
-  const isExternal = forceExternal || url.isExternal(href) || isPdf
+  const isExternal = url.isExternal(href) || isPdf
 
   // Get proper download link for internally hosted PDF's & static files (ex: whitepaper)
   // Opens in separate window.

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -28,6 +28,7 @@ type BaseProps = {
   hideArrow?: boolean
   isPartiallyActive?: boolean
   activeStyle?: StyleProps
+  forceExternal?: boolean
   // customEventOptions?: MatomoEventOptions
   // dir?: Direction // TODO: remove this prop once we use the native Chakra RTL support
 }
@@ -56,6 +57,7 @@ export const BaseLink: LinkComponent = forwardRef(function Link(props, ref) {
     hideArrow,
     isPartiallyActive = true,
     activeStyle = { color: "primary.base" },
+    forceExternal,
     ...rest
   } = props
 
@@ -66,7 +68,7 @@ export const BaseLink: LinkComponent = forwardRef(function Link(props, ref) {
 
   const isDiscordInvite = url.isDiscordInvite(href)
   const isPdf = url.isPdf(href)
-  const isExternal = url.isExternal(href) || isPdf
+  const isExternal = forceExternal || url.isExternal(href) || isPdf
 
   // Get proper download link for internally hosted PDF's & static files (ex: whitepaper)
   // Opens in separate window.

--- a/src/components/MarkdownImage.tsx
+++ b/src/components/MarkdownImage.tsx
@@ -30,7 +30,7 @@ const MarkdownImage = ({
     // display the wrapper as a `span` to avoid dom nesting warnings as mdx
     // sometimes wraps images in `p` tags
     <Flex as="span" justify="center">
-      <Link href={rest.src.toString()} hideArrow forceExternal>
+      <Link href={rest.src.toString()} target="_blank">
         <Image
           width={imageWidth}
           height={imageHeight}

--- a/src/components/MarkdownImage.tsx
+++ b/src/components/MarkdownImage.tsx
@@ -30,7 +30,7 @@ const MarkdownImage = ({
     // display the wrapper as a `span` to avoid dom nesting warnings as mdx
     // sometimes wraps images in `p` tags
     <Flex as="span" justify="center">
-      <Link href={rest.src.toString()} target="_blank">
+      <Link href={rest.src.toString()} target="_blank" rel="noopener">
         <Image
           width={imageWidth}
           height={imageHeight}

--- a/src/components/MarkdownImage.tsx
+++ b/src/components/MarkdownImage.tsx
@@ -1,6 +1,7 @@
 import { Flex } from "@chakra-ui/react"
 
-import { Image, type ImageProps } from "./Image"
+import Link from "@/components/Link"
+import { Image, type ImageProps } from "@/components/Image"
 import { CONTENT_IMAGES_MAX_WIDTH } from "@/lib/constants"
 
 interface MarkdownImageProps extends Omit<ImageProps, "width" | "height"> {
@@ -29,7 +30,14 @@ const MarkdownImage = ({
     // display the wrapper as a `span` to avoid dom nesting warnings as mdx
     // sometimes wraps images in `p` tags
     <Flex as="span" justify="center">
-      <Image width={imageWidth} height={imageHeight} loading="lazy" {...rest} />
+      <Link href={rest.src.toString()} hideArrow forceExternal>
+        <Image
+          width={imageWidth}
+          height={imageHeight}
+          loading="lazy"
+          {...rest}
+        />
+      </Link>
     </Flex>
   )
 }


### PR DESCRIPTION
## Description
Simple attempt at auto-linking markdown images:
- Wraps the image returned from `MarkdownImage` component in a `Link`
- `href` set to `rest.src` as a string, to link to the same image being rendered
- `target="_blank"` used to force opening in new tab (parity with existing site) since the relative path will be parsed as an internal path using NextLink.
- Since the link is treated as an internal link still, no ↗&#xFE0E; arrow will be displayed by default

cc: @nhsz @pettinarip @corwintines Lemme know thoughts on this.. can test more with the translated images when avaiable.