### PR TITLE
Use useRouter locale; remove hardcoded language

### DIFF
--- a/src/components/History/NetworkUpgradeSummary.tsx
+++ b/src/components/History/NetworkUpgradeSummary.tsx
@@ -1,8 +1,7 @@
 // Libraries
 import { useEffect, useState } from "react"
 import { Flex, Stack, Text } from "@chakra-ui/react"
-// TODO: look for replacement lib when i18n is set up
-// import { useI18next } from "gatsby-plugin-react-i18next"
+import { useRouter } from "next/router"
 
 // Components
 import Emoji from "../Emoji"
@@ -26,9 +25,8 @@ interface IProps {
 const NetworkUpgradeSummary: React.FC<IProps> = ({ name }) => {
   const [formattedUTC, setFormattedUTC] = useState("")
 
-  // TODO: remove hardcoded locale "en" values when i18n is set up
-  // const { language } = useI18next()
-  const language = "en"
+  const { locale } = useRouter()
+
   // const localeForStatsBoxNumbers = getLocaleForNumberFormat(language as Lang)
   const localeForStatsBoxNumbers = "en"
 
@@ -45,7 +43,7 @@ const NetworkUpgradeSummary: React.FC<IProps> = ({ name }) => {
   // calculate date format only on the client side to avoid hydration issues
   useEffect(() => {
     const date = new Date(dateTimeAsString as any)
-    const formattedDate = date.toLocaleString(language, {
+    const formattedDate = date.toLocaleString(locale, {
       timeZone: "UTC",
       month: "short",
       day: "numeric",

--- a/src/components/Quiz/QuizSummary.tsx
+++ b/src/components/Quiz/QuizSummary.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react"
 import { Box, Flex, useMediaQuery } from "@chakra-ui/react"
+import { useRouter } from "next/router"
 
 import Text from "../OldText"
 import { numberToPercent } from "@/lib/utils/numberToPercent"
@@ -29,9 +30,8 @@ const QuizSummary: React.FC<IProps> = ({
   quizScore,
   setUserStats,
 }) => {
-  // TODO: Re-enable when i18n is implemented; remove placeholder
-  // const { language } = useI18next()
-  const language = "en"
+  const { locale } = useRouter()
+
   const [largerThanMobile] = useMediaQuery("(min-width: 30em)")
 
   const valueStyles = { fontWeight: "700", mb: 2 }
@@ -85,7 +85,7 @@ const QuizSummary: React.FC<IProps> = ({
       >
         <Flex>
           <Text {...valueStyles}>
-            {numberToPercent(ratioCorrect, language)}
+            {numberToPercent(ratioCorrect, locale)}
           </Text>
           <Text {...labelStyles}>
             {/* <Translation id="score" /> */}

--- a/src/layouts/Static.tsx
+++ b/src/layouts/Static.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, type HeadingProps, Icon, chakra } from "@chakra-ui/react"
+import { useRouter } from "next/router"
 
 import Breadcrumbs from "@/components/Breadcrumbs"
 import EnergyConsumptionChart from "@/components/EnergyConsumptionChart"
@@ -67,8 +68,7 @@ export const StaticLayout: React.FC<IProps> = ({
   tocItems,
   lastUpdatedDate,
 }) => {
-  // const { language } = useI18next()
-  const language = "en"
+  const { locale } = useRouter()
   const isRightToLeft = isLangRightToLeft(frontmatter.lang as Lang)
 
   return (
@@ -104,12 +104,12 @@ export const StaticLayout: React.FC<IProps> = ({
           <Breadcrumbs slug={slug} mb="8" />
           <Text
             color="text200"
-            dir={isLangRightToLeft(language as Lang) ? "rtl" : "ltr"}
+            dir={isLangRightToLeft(locale as Lang) ? "rtl" : "ltr"}
           >
             {/* TODO: add Translation when i18n is set up  */}
             {/* <Translation id="page-last-updated" />:{" "} */}
             Page last updated:{" "}
-            {getLocaleTimestamp(language as Lang, lastUpdatedDate!)}
+            {getLocaleTimestamp(locale as Lang, lastUpdatedDate!)}
           </Text>
           <TableOfContents
             position="relative"

--- a/src/layouts/Upgrade.tsx
+++ b/src/layouts/Upgrade.tsx
@@ -11,6 +11,7 @@ import {
   useToken,
 } from "@chakra-ui/react"
 import { MdExpandMore } from "react-icons/md"
+import { useRouter } from "next/router"
 
 import { BaseLink } from "@/components/Link"
 import BeaconChainActions from "@/components/BeaconChainActions"
@@ -154,8 +155,7 @@ export const UpgradeLayout: React.FC<IProps> = ({
 }) => {
   // TODO: Re-enabled after i18n is implemented
   // const { t } = useTranslation()
-  // const { language } = useI18next()
-  const language = "en"
+  const { locale } = useRouter()
 
   const isRightToLeft = isLangRightToLeft(frontmatter.lang as Lang)
 
@@ -205,7 +205,7 @@ export const UpgradeLayout: React.FC<IProps> = ({
             {/* TODO: Re-enable after i18n implemented */}
             {/* <Translation id="page-last-updated" />:{" "} */}
             Page last updated:{" "}
-            {getLocaleTimestamp(language as Lang, lastUpdatedDate!)}
+            {getLocaleTimestamp(locale as Lang, lastUpdatedDate!)}
           </LastUpdated>
         </TitleCard>
         {frontmatter.image && (


### PR DESCRIPTION
## Description
Circles back on migrated components that used `const language = "en"` as a temporary override

- Replaces these with `const { locale } = useRouter()` utilizing `next/router`
- Renames `language` to `locale` to match `useRouter`
