### PR TITLE
Patch ToC logic

### DIFF
--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -57,10 +57,6 @@ const TableOfContents: React.FC<IProps> = ({
 
   const activeHash = useActiveHash(titleIds)
 
-  // Exclude <h1> from TOC
-  if (items?.length === 1) {
-    items = items[0].items!
-  }
   if (!items) {
     return null
   }

--- a/src/lib/utils/toc.ts
+++ b/src/lib/utils/toc.ts
@@ -121,7 +121,8 @@ const addHeadingsAsItems = (headings: Array<string>, h = 2): Array<ToCItem> => {
 }
 
 /**
- * Splits the content by lines and filters out lines that don't start with #s
+ * Splits the content by lines and filters out lines that don't start with at least two #'s (h2 or deeper)
+ * Note: each file should only have one h1, and it is not included in the ToC
  * Calls `addHeadingAsItem` with array of Markdown headers to generate list of `Item` objects
  * @param content Markdown content as a string (all lines)
  * @returns List of `Item` objects parsed from the content, nested according to heading depth

--- a/src/lib/utils/toc.ts
+++ b/src/lib/utils/toc.ts
@@ -110,7 +110,8 @@ const addHeadingsAsItems = (headings: Array<string>, h = 2): Array<ToCItem> => {
     if (depths[i + 1] > h) {
       const start = i + 1
       const rest = depths.slice(start)
-      const end = start + rest.indexOf(h)
+      const stepOutIndex = rest.indexOf(h)
+      const end = stepOutIndex < 0 ? headings.length : start + stepOutIndex
       const subHeadings = headings.slice(start, end)
       headingItem.items = addHeadingsAsItems(subHeadings, h + 1)
     }
@@ -128,6 +129,6 @@ const addHeadingsAsItems = (headings: Array<string>, h = 2): Array<ToCItem> => {
 export const generateTableOfContents = (content: string): Array<ToCItem> => {
   const contentWithoutComments = removeMarkdownComments(content)
   const lines = contentWithoutComments.split("\n")
-  const headings = lines.filter((line) => line.startsWith("#"))
+  const headings = lines.filter((line) => line.startsWith("##"))
   return addHeadingsAsItems(headings)
 }


### PR DESCRIPTION
## Description
Patches some logic in the Table of Contents component
- Improved `end` index calculation by considering case when none found and takes the last index instead.
- Filters out the H1's while generating the ToC (each page should only have one, and it is not shown in the ToC).
- Removed old logic accounting for H1's which were looking for toc items with only 1 item, and it assume that was an H1 which was ignored, and only nested items were shown... this causes bugs in current setup if there is only one H2 on the page with H3's... only the H3's were being shown.
