### PR TITLE
Move getLastDeployDate to dedicated util file

### DIFF
--- a/src/lib/utils/getLastDeployDate.ts
+++ b/src/lib/utils/getLastDeployDate.ts
@@ -1,0 +1,3 @@
+import published from "@/data/published.json"
+
+export const getLastDeployDate = () => new Date(published.date).toISOString()

--- a/src/lib/utils/gh.ts
+++ b/src/lib/utils/gh.ts
@@ -2,8 +2,6 @@ import fs from "fs"
 import { join } from "path"
 import { execSync } from "child_process"
 
-import published from "@/data/published.json"
-
 import { CONTENT_DIR, DEFAULT_LOCALE, TRANSLATIONS_DIR } from "@/lib/constants"
 
 // This util filters the git log to get the file last commit info, and then the commit date (last update)
@@ -33,5 +31,3 @@ export const getLastModifiedDate = (slug: string, locale: string) => {
 
   return new Date(lastCommitDate).toISOString()
 }
-
-export const getLastDeployDate = () => new Date(published.date).toISOString()

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -6,7 +6,8 @@ import remarkGfm from "remark-gfm"
 import { join } from "path"
 
 import { getContent, getContentBySlug } from "@/lib/utils/md"
-import { getLastDeployDate, getLastModifiedDate } from "@/lib/utils/gh"
+import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLastModifiedDate } from "@/lib/utils/gh"
 import rehypeImg from "@/lib/rehype/rehypeImg"
 import rehypeHeadingIds from "@/lib/rehype/rehypeHeadingIds"
 

--- a/src/pages/developers/tutorials/[...tutorial].tsx
+++ b/src/pages/developers/tutorials/[...tutorial].tsx
@@ -7,7 +7,8 @@ import path from "path"
 
 import { getContentBySlug } from "@/lib/utils/md"
 import rehypeImg from "@/lib/rehype/rehypeImg"
-import { getLastDeployDate, getLastModifiedDate } from "@/lib/utils/gh"
+import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getLastModifiedDate } from "@/lib/utils/gh"
 
 // Components
 import PageMetadata from "@/components/PageMetadata"


### PR DESCRIPTION
## Description
- Moves `getLastDeployDate` function to new dedicated utility file, `getLastDeployDate.ts`

## Related Issue
The `getLastDeployDate` utility recently merged is located in the `gh.ts` utility file, though it no longer has anything to do with GitHub and is simply reading a saved json file updated/committed with `yarn version` is run. 