### PR TITLE
i18n: patch html lang

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,15 +1,8 @@
-import { GetStaticProps } from "next"
 import { Html, Head, Main, NextScript } from "next/document"
-import { useRouter } from "next/router"
 
-export const getStaticProps: GetStaticProps = async () => {
-  const { locale } = useRouter()
-  return { props: { locale } }
-}
-
-export default function Document({ locale }) {
+export default function Document() {
   return (
-    <Html lang={locale}>
+    <Html>
       <Head />
       <body>
         <Main />


### PR DESCRIPTION
NextJS automatically sets the proper `lang` (https://nextjs.org/docs/pages/building-your-application/routing/internationalization#search-engine-optimization), no need to pass the `locale` prop

## To test

Open any allowed page, change the locale, open dev tools and see `lang` being set properly on html

<img width="670" alt="Screen Shot 2023-11-02 at 11 27 12" src="https://github.com/ethereum/ethereum-org-fork/assets/948922/944161ce-8665-4624-9779-7b2ab39e9491">
