### PR TITLE
fix: external pdf links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -66,11 +66,12 @@ export const BaseLink: LinkComponent = forwardRef(function Link(props, ref) {
 
   const isDiscordInvite = url.isDiscordInvite(href)
   const isPdf = url.isPdf(href)
-  const isExternal = url.isExternal(href) || isPdf
+  const isExternal = url.isExternal(href)
+  const isInternalPdf = isPdf && !isExternal
 
   // Get proper download link for internally hosted PDF's & static files (ex: whitepaper)
   // Opens in separate window.
-  if (isPdf) {
+  if (isInternalPdf) {
     href = getRelativePath(asPath, href)
   }
 
@@ -85,7 +86,7 @@ export const BaseLink: LinkComponent = forwardRef(function Link(props, ref) {
     ...(isActive && activeStyle),
   }
 
-  if (isExternal) {
+  if (isInternalPdf || isExternal) {
     return (
       <ChakraLink {...commonProps} isExternal>
         {children}

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -9,7 +9,7 @@ export const isExternal = (href: string): boolean =>
 export const isGlossary = (href: string): boolean =>
   href.includes("glossary") && href.includes("#")
 
-export const isPdf = (href: string): boolean => href.includes(".pdf")
+export const isPdf = (href: string): boolean => href.endsWith(".pdf")
 
 export const sanitizeHitUrl = (url: string): string =>
   url


### PR DESCRIPTION
This PR updates `Link` component to handle external PDFs properly

## Description

To test it, check that whitepaper PDF link still works as expected on `/whitepaper` page and `A detailed report by the Taskforce for Scaling Voluntary Carbon Markets` link mentioned on issue now works as expected on `/refi` page

Fixes #102 
