### PR TITLE
[TEST] perf(_app): use `ChakraBaseProvider`

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,5 @@
-import { ReactNode } from "react"
-// ChakraProvider import updated as recommended on https://github.com/chakra-ui/chakra-ui/issues/4975#issuecomment-1174234230
-// to reduce bundle size. Should be reverted to "@chakra-ui/react" in case on theme issues
-import { ChakraProvider } from "@chakra-ui/provider"
+import { ChakraBaseProvider } from "@chakra-ui/react"
+
 // Chakra custom theme
 import theme from "@/@chakra-ui/theme"
 // Fonts
@@ -24,9 +22,9 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
           }
         `}
       </style>
-      <ChakraProvider theme={theme}>
+      <ChakraBaseProvider theme={theme}>
         {getLayout(<Component {...pageProps} />)}
-      </ChakraProvider>
+      </ChakraBaseProvider>
     </>
   )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In reviewing https://github.com/chakra-ui/chakra-ui/issues/4975#issuecomment-1174234230, the resolution made for the bundle size issue was to introduce `ChakraBaseProvider`, so that the build did not include the component themes when `import { ChakraBaseProvider } from "@chakra-ui/react"`. Most of the bundle size issues come from these themes.

This would be used in conjunction with `extendBaseTheme` to not use all the default component themes from Chakra either in production or in build, and to only bring them into the project selectively.

Review [Chakra Changelog v2.4.2](https://chakra-ui.com/changelog/v2.4.2#react-242)

Would like to know if there any unexpected issues here.

<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
