### PR TITLE
Fix translations not loading in some pages

### DIFF
--- a/src/components/EnergyConsumptionChart.tsx
+++ b/src/components/EnergyConsumptionChart.tsx
@@ -209,7 +209,7 @@ const EnergyConsumptionChart: React.FC = () => {
             <Legend
               content={
                 <Box textAlign="center" color="text" fontWeight="600" mt={8}>
-                  <Translation id="page-what-is-ethereum-energy-consumption-chart-legend" />
+                  {t("page-what-is-ethereum:page-what-is-ethereum-energy-consumption-chart-legend")}
                 </Box>
               }
             />

--- a/src/components/Translation.tsx
+++ b/src/components/Translation.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 
 import InlineLink from "./Link"
+import { getRequiredNamespacesForPath } from "@/lib/utils/translations"
 
 interface Props {
   id: string
@@ -19,34 +20,8 @@ const transform = {
 // Renders the translation string for the given translation key `id`. It
 // fallback to English if it doesn't find the given key in the current language
 const Translation = ({ id, options }: Props) => {
-  const [requiredNamespaces, setRequiredNamespaces] = useState<string[]>([])
   const { asPath } = useRouter()
-
-  useEffect(() => {
-    if (asPath.startsWith("/community")) {
-      setRequiredNamespaces([...requiredNamespaces, "page-community"])
-    }
-
-    if (asPath.startsWith("/energy-consumption")) {
-      setRequiredNamespaces([
-        ...requiredNamespaces,
-        "page-about",
-        "page-what-is-ethereum",
-      ])
-    }
-
-    if (asPath.startsWith("/history")) {
-      setRequiredNamespaces([...requiredNamespaces, "page-history"])
-    }
-
-    if (asPath.startsWith("/nft")) {
-      setRequiredNamespaces([...requiredNamespaces, "learn-quizzes"])
-    }
-
-    if (asPath.startsWith("/staking")) {
-      setRequiredNamespaces([...requiredNamespaces, "page-staking"])
-    }
-  }, [requiredNamespaces])
+  const requiredNamespaces = getRequiredNamespacesForPath(asPath)
 
   const { t } = useTranslation(requiredNamespaces)
   const translatedText = t(id, options)

--- a/src/components/Translation.tsx
+++ b/src/components/Translation.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react"
 import htmr from "htmr"
 import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"

--- a/src/lib/utils/translations.ts
+++ b/src/lib/utils/translations.ts
@@ -15,3 +15,33 @@ export const isLangRightToLeft = (lang: Lang): boolean => {
 // Context: https://github.com/ethereum/ethereum-org-website/pull/5490#pullrequestreview-892596553
 export const getLocaleForNumberFormat = (locale: Lang): Lang =>
   locale === "fa" ? DEFAULT_LOCALE : locale
+
+export const getRequiredNamespacesForPath = (path: string) => {
+  let requiredNamespaces: string[] = ["common"]
+
+  if (path.startsWith("/community")) {
+    requiredNamespaces = [...requiredNamespaces, "page-community"]
+  }
+
+  if (path.startsWith("/energy-consumption")) {
+    requiredNamespaces = [
+      ...requiredNamespaces,
+      "page-about",
+      "page-what-is-ethereum",
+    ]
+  }
+
+  if (path.startsWith("/history")) {
+    requiredNamespaces = [...requiredNamespaces, "page-history"]
+  }
+
+  if (path.startsWith("/nft")) {
+    requiredNamespaces = [...requiredNamespaces, "learn-quizzes"]
+  }
+
+  if (path.startsWith("/staking")) {
+    requiredNamespaces = [...requiredNamespaces, "page-staking"]
+  }
+
+  return requiredNamespaces
+}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -39,6 +39,7 @@ import {
 } from "@/layouts"
 import rehypeHeadingIds from "@/lib/rehype/rehypeHeadingIds"
 import rehypeImg from "@/lib/rehype/rehypeImg"
+import { getRequiredNamespacesForPath } from "@/lib/utils/translations"
 
 const layoutMapping = {
   static: StaticLayout,
@@ -141,9 +142,12 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (
     }
   }
 
+  // load i18n required namespaces for the given page
+  const requiredNamespaces = getRequiredNamespacesForPath(originalSlug)
+
   return {
     props: {
-      ...(await serverSideTranslations(locale!, ["common"])), // load i18n required namespace for all pages
+      ...(await serverSideTranslations(locale!, requiredNamespaces)),
       mdxSource,
       originalSlug,
       frontmatter,


### PR DESCRIPTION
## Description

As we were passing only the `common` namespace to the `serverSideTranslations` function, the rest of the namespaces were not loaded correctly.

This PR adds the necessary namespaces for a given page path/slug on server-side, and reuses the logic in the client-side `Translation` component.

## Related Issue

Fixes #117