### PR TITLE
ToC Logic

### DIFF
--- a/src/lib/utils/toc.ts
+++ b/src/lib/utils/toc.ts
@@ -5,7 +5,7 @@ import type { SourceHeadingItem, ToCItem } from "@/lib/types"
 // RegEx patterns
 const customIdRegEx = /^.+(\s*\{#([^\}]+?)\}\s*)$/
 const unicodeEmojiRegEx = /\\u{[0-9A-F]+}/gi
-const unicodeIntlRegEx = /(\\u[0-9A-F]{2,4}|\\x[0-9A-F]{2})/gi
+const unicodeIntlRegEx = /(\\u[0-9A-F]{2,4}|\\x[0-9A-F]{2})/g
 const compiledSourceHeadingRegEx =
   /mdx\("h([2-4])",\w+?\(.+?\{id:"([^"]+)"\}\)((,("([^"]+)"|mdx\([^\)]+\)))+)\)/g
 const mdxShallowFncRegEx = /mdx\("?(\w+)"?,\{[^\}]+\}(,\"([^\"]+)\")?\)/g

--- a/src/lib/utils/toc.ts
+++ b/src/lib/utils/toc.ts
@@ -5,7 +5,7 @@ import type { SourceHeadingItem, ToCItem } from "@/lib/types"
 // RegEx patterns
 const customIdRegEx = /^.+(\s*\{#([^\}]+?)\}\s*)$/
 const unicodeEmojiRegEx = /\\u{[0-9A-F]+}/gi
-const unicodeIntlRegEx = /\\u[0-9A-F]+/gi
+const unicodeIntlRegEx = /(\\u[0-9A-F]{2,4}|\\x[0-9A-F]{2})/gi
 const compiledSourceHeadingRegEx =
   /mdx\("h([2-4])",\w+?\(.+?\{id:"([^"]+)"\}\)((,("([^"]+)"|mdx\([^\)]+\)))+)\)/g
 const mdxShallowFncRegEx = /mdx\("?(\w+)"?,\{[^\}]+\}(,\"([^\"]+)\")?\)/g


### PR DESCRIPTION
## Description
Encountered additional edge cases with non-standard characters. 

- This adjusts the regex matcher to also parse `\x` characters, ie `\\xFC` -> `ü` and `\\xE7` -> `ç`
- Also adjusts the logic for `\u` characters by limiting the match to 2-4 (`{2,4}`) characters after a `\\u` is spotted, and removing case-insensitive (`i`) flag to match uppercase only for hex values... ie, when parsing `ke\\u015Ffedin` it was matching `\\u015Ffed` when it should only match `\\u015F`

## Related Issue
