### PR TITLE
Remove `react/no-unescaped-entities` eslint enforcement

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
         ]
       }
     ],
-    "simple-import-sort/exports": "error"
+    "simple-import-sort/exports": "error",
+    "react/no-unescaped-entities": "off"
   }
 }


### PR DESCRIPTION
## Issue
With recent eslint setup, we're now getting errors when using unescaped entities

![image](https://github.com/ethereum/ethereum-org-fork/assets/54227730/3c757a12-e93a-4ff7-a6ed-43104676c637)

## Description
- Disabled eslint rule for `react/no-unescaped-entities` to allow use of apostrophes, quotations, etc as we've done in the past.
