### PR TITLE
Implement Matomo tracking in Link component

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -88,7 +88,6 @@ export const BaseLink = forwardRef(function Link(
   if (isInternalPdf || isExternal) {
     return (
       <ChakraLink
-        {...commonProps}
         isExternal
         onClick={() =>
           trackCustomEvent(
@@ -102,6 +101,7 @@ export const BaseLink = forwardRef(function Link(
             }
           )
         }
+        {...commonProps}
       >
         {children}
         <VisuallyHidden>(opens in a new tab)</VisuallyHidden>
@@ -122,7 +122,6 @@ export const BaseLink = forwardRef(function Link(
   return (
     <NextLink
       locale={locale}
-      {...commonProps}
       onClick={() =>
         trackCustomEvent(
           customEventOptions ?? {
@@ -133,6 +132,7 @@ export const BaseLink = forwardRef(function Link(
           }
         )
       }
+      {...commonProps}
     >
       {children}
     </NextLink>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -21,17 +21,14 @@ import { DISCORD_PATH, SITE_URL } from "@/lib/constants"
 import { useRtlFlip } from "@/hooks/useRtlFlip"
 
 type BaseProps = {
+  /** @deprecated Use `href` prop instead */
+  to?: string
+  href?: string
   hideArrow?: boolean
   isPartiallyActive?: boolean
   activeStyle?: StyleProps
   customEventOptions?: MatomoEventOptions
-} & (
-  | {
-      /** @deprecated Use `href` prop instead */
-      to: string
-    }
-  | { href: string }
-)
+}
 
 export type LinkProps = BaseProps & Omit<NextLinkProps, "href">
 
@@ -49,6 +46,8 @@ export type LinkProps = BaseProps & Omit<NextLinkProps, "href">
  */
 export const BaseLink = forwardRef(function Link(
   {
+    to,
+    href: hrefProp,
     children,
     hideArrow,
     isPartiallyActive = true,
@@ -58,7 +57,7 @@ export const BaseLink = forwardRef(function Link(
   }: LinkProps,
   ref
 ) {
-  let href = "to" in props ? props.to : props.href
+  let href = (to ?? hrefProp) as string
 
   const { asPath, locale } = useRouter()
   const { flipForRtl } = useRtlFlip()

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,4 +1,4 @@
-import { DISCORD_PATH } from "../constants"
+import { DISCORD_PATH } from "@/lib/constants"
 
 export const isDiscordInvite = (href: string): boolean =>
   href.includes(DISCORD_PATH) && !href.includes("http")


### PR DESCRIPTION
## Description
- Add Matomo tracking into Link component
- Update typing on Link component to require a `to` or `href`

## Related Issue
https://www.notion.so/efdn/Add-customEventOptions-prop-back-to-ButtonLink-Link-ef2e0044450b4399b681fce5b3ce937d?pvs=4