### PR TITLE
Home page - remove revalidate option

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -197,7 +197,6 @@ export const getStaticProps = (async (context) => {
       communityEvents,
       lastDeployDate,
     },
-    revalidate: BASE_TIME_UNIT * 24, // Rebuilds page daily
   }
 }) satisfies GetStaticProps<Props>
 


### PR DESCRIPTION
Atm the [home page](https://ethereum-org-fork.netlify.app/) is throwing a 500 error.

## Description

This PR removes the `revalidate' option to work around the problem for now. We will add it again after we investigate what is going on.