### PR TITLE
Implement `unoptimized` for animated images

### DIFF
--- a/src/components/MarkdownImage.tsx
+++ b/src/components/MarkdownImage.tsx
@@ -1,3 +1,5 @@
+import { extname } from "path"
+
 import { Flex } from "@chakra-ui/react"
 
 import { Image, type ImageProps } from "@/components/Image"
@@ -34,6 +36,9 @@ const MarkdownImage = ({
     imageHeight = CONTENT_IMAGES_MAX_WIDTH / imageAspectRatio
   }
 
+  const fileExt = extname(transformedSrc).toLowerCase()
+  const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)  
+
   return (
     // display the wrapper as a `span` to avoid dom nesting warnings as mdx
     // sometimes wraps images in `p` tags
@@ -45,6 +50,7 @@ const MarkdownImage = ({
           height={imageHeight}
           loading="lazy"
           src={transformedSrc}
+          unoptimized={isAnimated}
           {...rest}
         />
       </Link>


### PR DESCRIPTION
## Description
Force `unoptimized` prop for supported animated image file types. 

Docs: https://nextjs.org/docs/pages/api-reference/components/image#animated-images

## Preview link
https://deploy-preview-172--ethereum-org-fork.netlify.app/en/developers/tutorials/how-to-mint-an-nft

## Related Issue
https://www.notion.so/efdn/Images-Investigate-broken-images-e20e287a82c0425c82ef3de12bd8c7f2?pvs=4