### PR TITLE
Add vision page, update associated components

### DIFF
--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -28,7 +28,7 @@ type ButtonType = Omit<ButtonProps, "content"> & {
   matomo: MatomoEventOptions
 }
 
-type ContentType = {
+export type ContentType = {
   buttons?: (ButtonLinkType | ButtonType)[]
   title: ReactNode
   header: ReactNode

--- a/src/components/Trilemma/index.tsx
+++ b/src/components/Trilemma/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import { useTranslation } from "next-i18next"
 import {
   Drawer,
   DrawerCloseButton,
@@ -9,17 +9,16 @@ import {
   useToken,
 } from "@chakra-ui/react"
 
-import Card from "../Card"
-import OldHeading from "../OldHeading"
-import Text from "../OldText"
-import Translation from "../Translation"
+import Card from "@/components/Card"
+import OldHeading from "@/components/OldHeading"
+import Text from "@/components/OldText"
 
-import { IProps as TriangleSVGProps,TriangleSVG } from "./Triangle"
+import { IProps as TriangleSVGProps, TriangleSVG } from "./Triangle"
 import { useTrilemma } from "./useTrilemma"
 
-export interface IProps {}
+const Trilemma = () => {
+  const { t } = useTranslation("page-roadmap-vision")
 
-const Trilemma: React.FC<IProps> = () => {
   const {
     trilemmaChecks,
     mobileModalOpen,
@@ -53,19 +52,19 @@ const Trilemma: React.FC<IProps> = () => {
         }}
       >
         <OldHeading fontSize="2rem" mt={0}>
-          <Translation id="page-roadmap-vision-trilemma-h2" />
+          {t("page-roadmap-vision-trilemma-h2")}
         </OldHeading>
         <Text>
-          <Translation id="page-roadmap-vision-trilemma-p" />
+          {t("page-roadmap-vision-trilemma-p")}
         </Text>
         <Text>
-          <Translation id="page-roadmap-vision-trilemma-p-1" />
+          {t("page-roadmap-vision-trilemma-p-1")}
         </Text>
         <Text>
-          <Translation id="page-roadmap-vision-trilemma-p-2" />
+          {t("page-roadmap-vision-trilemma-p-2")}
         </Text>
         <Text fontWeight={600} hideFrom={lgBp}>
-          <Translation id="page-roadmap-vision-trilemma-modal-tip" />:
+          {t("page-roadmap-vision-trilemma-modal-tip")}:
         </Text>
         <Card {...cardDetail} mt={8} minH="300px" hideBelow={lgBp} />
       </Flex>

--- a/src/components/Trilemma/useTrilemma.tsx
+++ b/src/components/Trilemma/useTrilemma.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react"
+import { useState } from "react"
+import { useTranslation } from "next-i18next"
 
 import { IProps as CardProps } from "../Card"
-import Translation from "../Translation"
 
 /**
  * The `selection` param accepted values for the click handler
@@ -13,6 +13,8 @@ export type HandleClickParam =
   | "isScalableAndSecure"
 
 export const useTrilemma = () => {
+  const { t } = useTranslation("page-roadmap-vision")
+
   const [state, setState] = useState({
     isDecentralizedAndSecure: false,
     isDecentralizedAndScalable: false,
@@ -73,20 +75,20 @@ export const useTrilemma = () => {
     })
   }
 
-  let cardTitle = <Translation id="page-roadmap-vision-trilemma-title-1" />
-  let cardText = <Translation id="page-roadmap-vision-trilemma-press-button" />
+  let cardTitle = t("page-roadmap-vision-trilemma-title-1")
+  let cardText = t("page-roadmap-vision-trilemma-press-button")
   if (isEthereum) {
-    cardTitle = <Translation id="page-roadmap-vision-trilemma-title-2" />
-    cardText = <Translation id="page-roadmap-vision-trilemma-cardtext-1" />
+    cardTitle = t("page-roadmap-vision-trilemma-title-2")
+    cardText = t("page-roadmap-vision-trilemma-cardtext-1")
   } else if (state.isDecentralizedAndSecure) {
-    cardTitle = <Translation id="page-roadmap-vision-trilemma-title-3" />
-    cardText = <Translation id="page-roadmap-vision-trilemma-cardtext-2" />
+    cardTitle = t("page-roadmap-vision-trilemma-title-3")
+    cardText = t("page-roadmap-vision-trilemma-cardtext-2")
   } else if (state.isDecentralizedAndScalable) {
-    cardTitle = <Translation id="page-roadmap-vision-trilemma-title-4" />
-    cardText = <Translation id="page-roadmap-vision-trilemma-cardtext-3" />
+    cardTitle = t("page-roadmap-vision-trilemma-title-4")
+    cardText = t("page-roadmap-vision-trilemma-cardtext-3")
   } else if (state.isScalableAndSecure) {
-    cardTitle = <Translation id="page-roadmap-vision-trilemma-title-5" />
-    cardText = <Translation id="page-roadmap-vision-trilemma-cardtext-4" />
+    cardTitle = t("page-roadmap-vision-trilemma-title-5")
+    cardText = t("page-roadmap-vision-trilemma-cardtext-4")
   }
 
   return {

--- a/src/lib/utils/translations.ts
+++ b/src/lib/utils/translations.ts
@@ -110,6 +110,10 @@ const getRequiredNamespacesForPath = (path: string) => {
     requiredNamespaces = [...requiredNamespaces, "page-languages"]
   }
 
+  if (path.startsWith("/roadmap/vision")) {
+    requiredNamespaces = [...requiredNamespaces, "page-roadmap-vision", "page-upgrades-index"]
+  }
+
   // Quizzes
   // Note: Add any URL paths that have quizzes here
   if (

--- a/src/pages/roadmap/vision.tsx
+++ b/src/pages/roadmap/vision.tsx
@@ -108,6 +108,10 @@ const TrilemmaContent = (props: ChildOnlyProp) => (
   <Box w="full" my={8} mx={0} p={8} background="cardGradient" {...props} />
 )
 
+type Props = SSRConfig & {
+  lastDeployDate: string
+}
+
 export const getStaticProps = (async (context) => {
   const { locale } = context
 
@@ -121,7 +125,7 @@ export const getStaticProps = (async (context) => {
       lastDeployDate,
     },
   }
-}) satisfies GetStaticProps<SSRConfig>
+}) satisfies GetStaticProps<Props>
 
 const VisionPage = () => {
   const { t } = useTranslation(["page-roadmap-vision", "page-upgrades-index"])

--- a/src/pages/roadmap/vision.tsx
+++ b/src/pages/roadmap/vision.tsx
@@ -1,0 +1,287 @@
+import { GetStaticProps } from "next"
+import { useRouter } from "next/router"
+import { SSRConfig, useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import type { ComponentPropsWithRef } from "react"
+import {
+  Box,
+  Divider,
+  Flex,
+  type FlexProps,
+  Heading,
+  type HeadingProps,
+  List,
+  ListItem,
+  useToken,
+} from "@chakra-ui/react"
+
+import type { ChildOnlyProp } from "@/lib/types"
+
+import Breadcrumbs from "@/components/Breadcrumbs"
+import ButtonLink from "@/components/Buttons/ButtonLink"
+import Card from "@/components/Card"
+import Emoji from "@/components/Emoji"
+import FeedbackCard from "@/components/FeedbackCard"
+import InfoBanner from "@/components/InfoBanner"
+import InlineLink from "@/components/Link"
+import OldHeading from "@/components/OldHeading"
+import Text from "@/components/OldText"
+import PageHero, {
+  type ContentType as PageHeroContent,
+} from "@/components/PageHero"
+import PageMetadata from "@/components/PageMetadata"
+import Trilemma from "@/components/Trilemma"
+
+import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
+import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
+
+import oldship from "@/public/upgrades/oldship.png"
+
+const Page = (props: ChildOnlyProp) => (
+  <Flex direction="column" align="center" w="full" {...props} />
+)
+
+const PageDivider = () => (
+  <Divider
+    my={16}
+    w="10%"
+    borderBottomWidth="0.25rem"
+    borderColor="homeDivider"
+  />
+)
+
+const PageContent = (props: ChildOnlyProp) => (
+  <Flex flexDirection="column" gap="8" py={4} px={8} w="full" {...props} />
+)
+
+const H2 = (props: HeadingProps) => (
+  <Heading
+    as="h2"
+    mb={8}
+    fontSize={{ base: "2xl", md: "2rem" }}
+    fontWeight="semibold"
+    lineHeight={1.4}
+    {...props}
+  />
+)
+
+const CenterH2 = (props: HeadingProps) => <H2 textAlign="center" {...props} />
+
+const H3 = (props: HeadingProps) => (
+  <OldHeading
+    as="h3"
+    fontSize={{ base: "xl", md: "2xl" }}
+    fontWeight="semibold"
+    lineHeight={1.4}
+    {...props}
+  />
+)
+
+const CardContainer = (props: FlexProps) => (
+  <Flex wrap="wrap" mx={-4} {...props} />
+)
+
+const ProblemCardContainer = (props: ChildOnlyProp) => {
+  const containerMaxWidth = useToken("breakpoints", ["lg"])
+
+  return <CardContainer maxW={containerMaxWidth} m="0 auto" {...props} />
+}
+
+const CentreCard = (props: ComponentPropsWithRef<typeof Card>) => (
+  <Card
+    flex="1 1 30%"
+    minW="240px"
+    m={4}
+    page-upgrades-proof-stake-link
+    p={6}
+    border={0}
+    textAlign="center"
+    {...props}
+  />
+)
+
+const CentralContent = (props: ChildOnlyProp) => (
+  <Box my={0} mx={{ base: 0, lg: 48 }} {...props} />
+)
+
+const TrilemmaContent = (props: ChildOnlyProp) => (
+  <Box w="full" my={8} mx={0} p={8} background="cardGradient" {...props} />
+)
+
+export const getStaticProps = (async (context) => {
+  const { locale } = context
+
+  // load i18n required namespaces for the given page
+  const requiredNamespaces = getRequiredNamespacesForPage("/roadmap/vision")
+  const lastDeployDate = getLastDeployDate()
+
+  return {
+    props: {
+      ...(await serverSideTranslations(locale!, requiredNamespaces)),
+      lastDeployDate,
+    },
+  }
+}) satisfies GetStaticProps<SSRConfig>
+
+const VisionPage = () => {
+  const { t } = useTranslation(["page-roadmap-vision", "page-upgrades-index"])
+  const { pathname } = useRouter()
+
+  const paths = [
+    {
+      emoji: ":vertical_traffic_light:",
+      title: t("page-roadmap-vision-title-1"),
+      description: t("page-roadmap-vision-desc-1"),
+    },
+    {
+      emoji: ":minidisc:",
+      title: t("page-roadmap-vision-title-2"),
+      description: t("page-roadmap-vision-desc-2"),
+    },
+  ]
+
+  const heroContent: PageHeroContent = {
+    title: t("page-roadmap-vision-title"),
+    header: t("page-roadmap-vision-future"),
+    subtitle: t("page-roadmap-vision-subtitle"),
+    image: oldship,
+    alt: t("page-eth-whats-eth-hero-alt"),
+  }
+
+  return (
+    <Page>
+      <PageMetadata
+        title={t("page-roadmap-vision-meta-title")}
+        description={t("page-roadmap-vision-meta-desc")}
+      />
+      <PageHero content={heroContent} />
+      <PageDivider />
+      <PageContent>
+        <Breadcrumbs slug={pathname} startDepth={1} />
+        <CentralContent>
+          <CenterH2>{t("page-roadmap-vision-upgrade-needs")}</CenterH2>
+          <Text>{t("page-roadmap-vision-upgrade-needs-desc")}</Text>
+          <Text>{t("page-roadmap-vision-upgrade-needs-desc-2")}</Text>
+          <Text>{t("page-roadmap-vision-upgrade-needs-desc-3")} </Text>
+          <List listStyleType="disc">
+            <ListItem>
+              <InlineLink href="https://members.delphidigital.io/reports/the-hitchhikers-guide-to-ethereum">
+                {t("page-roadmap-vision-2022")}
+              </InlineLink>
+            </ListItem>
+            <ListItem>
+              <InlineLink href="https://trent.mirror.xyz/82eyq_NXZzzqFmCNXiKJgSdayf6omCW7BgDQIneyPoA">
+                {t("page-roadmap-vision-2021-updates")}
+              </InlineLink>
+            </ListItem>
+            <ListItem>
+              <InlineLink href="https://tim.mirror.xyz/CHQtTJb1NDxCK41JpULL-zAJe7YOtw-m4UDw6KDju6c">
+                {t("page-roadmap-vision-2021")}
+              </InlineLink>
+            </ListItem>
+            <ListItem>
+              <InlineLink href="https://blog.ethereum.org/2015/03/03/ethereum-launch-process/">
+                {t("page-roadmap-vision-upgrade-needs-serenity")}
+              </InlineLink>
+            </ListItem>
+            <ListItem>
+              <InlineLink href="https://blog.ethereum.org/2014/01/15/slasher-a-punitive-proof-of-stake-algorithm/">
+                {t("page-roadmap-vision-2014")}
+              </InlineLink>
+            </ListItem>
+          </List>
+          <Text>{t("page-roadmap-vision-upgrade-needs-desc-5")}</Text>
+          <Text>{t("page-roadmap-vision-upgrade-needs-desc-6")}</Text>
+        </CentralContent>
+      </PageContent>
+      <PageDivider />
+      <PageContent>
+        <CenterH2>{t("page-roadmap-vision-problems")}</CenterH2>
+        <ProblemCardContainer>
+          {paths.map((path, idx) => (
+            <CentreCard
+              key={idx}
+              emoji={path.emoji}
+              title={path.title}
+              description={path.description}
+            />
+          ))}
+        </ProblemCardContainer>
+      </PageContent>
+      <TrilemmaContent>
+        <Trilemma />
+      </TrilemmaContent>
+      <PageDivider />
+      <PageContent>
+        <CentralContent>
+          <CenterH2>{t("page-roadmap-vision-understanding")}</CenterH2>
+          <H3>
+            {t("page-roadmap-vision-scalability")} <Emoji text=":rocket:" />
+          </H3>
+          <Text>{t("page-roadmap-vision-scalability-desc")}</Text>
+          <Text>{t("page-roadmap-vision-scalability-desc-3")}</Text>
+          <Text>
+            {t("page-roadmap-vision-scalability-desc-4")}{" "}
+            <InlineLink href="/roadmap/danksharding/">
+              {t("page-roadmap-vision-danksharding")}
+            </InlineLink>{" "}
+          </Text>
+          <H3>
+            {t("page-roadmap-vision-security")} <Emoji text=":shield:" />
+          </H3>
+          <Text>{t("page-roadmap-vision-security-desc")}</Text>
+          <Text>
+            {t("page-roadmap-vision-security-desc-3")}{" "}
+            <InlineLink href="/developers/docs/consensus-mechanisms/pos/">
+              {t("page-upgrades-index:page-upgrades-proof-stake-link")}
+            </InlineLink>{" "}
+          </Text>
+          <Text>
+            {t("page-roadmap-vision-security-desc-5")}{" "}
+            <InlineLink href="/developers/docs/consensus-mechanisms/pow/">
+              {t("page-roadmap-vision-security-desc-5-link")}
+            </InlineLink>
+          </Text>
+          <Text>{t("page-roadmap-vision-security-desc-10")}</Text>
+          <Text>
+            {t("page-roadmap-vision-security-validator")}{" "}
+            <InlineLink href="/run-a-node/">
+              {t("page-roadmap-vision-ethereum-node")}
+            </InlineLink>
+          </Text>
+          <ButtonLink href="/staking/">
+            {t("page-roadmap-vision-security-staking")}
+          </ButtonLink>
+          <H3>
+            {t("page-roadmap-vision-sustainability")}{" "}
+            <Emoji text=":evergreen_tree:" />
+          </H3>
+          <Text>{t("page-roadmap-vision-sustainability-subtitle")}</Text>
+          <Text>
+            {t("page-roadmap-vision-sustainability-desc-1")}{" "}
+            <InlineLink href="/developers/docs/consensus-mechanisms/pow/mining/">
+              {t("page-roadmap-vision-mining")}
+            </InlineLink>
+          </Text>
+          <Text>
+            {t("page-roadmap-vision-sustainability-desc-2")}{" "}
+            <InlineLink href="/staking/">
+              {t("page-roadmap-vision-staking-lower")}
+            </InlineLink>
+          </Text>
+          <Text>{t("page-roadmap-vision-sustainability-desc-3")}</Text>
+          <InfoBanner>
+            <Text>{t("page-roadmap-vision-sustainability-desc-8")}</Text>
+            <ButtonLink href="/roadmap/merge/">
+              {t("page-upgrades-index:page-upgrades-merge-btn")}
+            </ButtonLink>
+          </InfoBanner>
+        </CentralContent>
+      </PageContent>
+      <PageDivider />
+      <FeedbackCard />
+    </Page>
+  )
+}
+
+export default VisionPage

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -113,9 +113,6 @@
     "./src/components/Tag/index.tsx",
     "./src/components/TitleCardList.tsx",
     "./src/components/TranslationLeaderboard.tsx",
-    "./src/components/Trilemma/Triangle.tsx",
-    "./src/components/Trilemma/index.tsx",
-    "./src/components/Trilemma/useTrilemma.tsx",
     "./src/components/UpgradeBannerNotification.tsx",
     "./src/hooks/useEthPrice.tsx"
   ]


### PR DESCRIPTION
## Description
- Migrates `/roadmap/vision` page
- Updates associated components for `next-i18next`

## Related Issue
https://www.notion.so/efdn/Migrate-React-pages-8acee0dc80d04e55b109e9852c20ef2f?pvs=4

## Preview links
https://deploy-preview-177--ethereum-org-fork.netlify.app/en/roadmap/vision