### PR TITLE
Add /web3 to learn-quizzes list

### DIFF
--- a/src/lib/utils/translations.ts
+++ b/src/lib/utils/translations.ts
@@ -135,6 +135,7 @@ const getRequiredNamespacesForPath = (path: string) => {
     path.startsWith("/nft") ||
     path.startsWith("/roadmap/merge") ||
     path.startsWith("/security") ||
+    path.startsWith("/web3") ||
     path.startsWith("/quizzes")
   ) {
     requiredNamespaces = [...requiredNamespaces, "learn-quizzes"]


### PR DESCRIPTION
## Description
- Adds `/web3` path to `getRequiredNamespacesForPath` for the `learn-quizzes` namespace

## Related Issue
Fixes https://www.notion.so/efdn/BUG-missing-translations-in-QuizWidget-9a2c4dc8b8e644719a8de8cae2a04ffd?pvs=4