### PR TITLE
Patch manifest and favicon

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -44,13 +44,13 @@
       "src": "/assets/manifest-homepage-screenshot.png",
       "type": "image/png",
       "sizes": "2048x1734",
-      "form_factor": "desktop"
+      "form_factor": "wide"
     },
     {
       "src": "/assets/manifest-homepage-screenshot-mobile.png",
       "type": "image/png",
       "sizes": "1290x2195",
-      "form_factor": "smartphone"
+      "form_factor": "narrow"
     }
   ]
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -26,9 +26,9 @@ class Document extends NextDocument {
       <Html dir={dir} lang={locale}>
         <Head>
           {/* favicon */}
-          <link rel="icon" type="image/x-icon" href="favicon.png" />
+          <link rel="icon" type="image/x-icon" href="/favicon.png" />
           {/* manifest */}
-          <link rel="manifest" href="manifest.json" />
+          <link rel="manifest" href="/manifest.json" />
         </Head>
         <body>
           <ColorModeScript initialColorMode={theme.config.initialColorMode} />


### PR DESCRIPTION
## Description
- Fix `form_factor` values (must be `narrow` or `wide`)
- Force `favicon.png` and `manifest.json` paths to root (`/`) level

## Related Issue
https://github.com/ethereum/ethereum-org-fork/pull/180#pullrequestreview-1778419279