### PR TITLE
Patch PageHero mobile image positioning

### DIFF
--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -150,6 +150,8 @@ const PageHero = ({
         maxWidth={{ base: "560px", lg: "624px" }}
         mt={{ base: 0, lg: 12 }}
         ms={{ base: 0, lg: 12 }}
+        w="full"
+        alignSelf="center"
       >
         <Image
           src={image}


### PR DESCRIPTION
## Description
- Fix positioning of PageHero image on mobile devices
- Adds `alignSelf="center"` and `w="full"` for parity with canonical repo

## Related Issue
<img width="858" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/8bd8bd06-c9c8-492d-b2c9-5438b9b12382">
<img width="903" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/0d4285f5-ac71-43ea-ac9a-7273082851b5">

## Screenshot of fix
<img width="987" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/6e296130-ec14-429d-912c-e03a7a366474">
<img width="889" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/75bd13de-ce8e-4a92-a30c-791ce3802805">

## Preview link
https://deploy-preview-185--ethereum-org-fork.netlify.app/en/run-a-node
Canonical https://ethereum.org/en/run-a-node/
https://deploy-preview-185--ethereum-org-fork.netlify.app/en/gas
Canonical https://ethereum.org/en/gas