### PR TITLE
Add key to UseCases hero, remount on path change

### DIFF
--- a/src/layouts/UseCases.tsx
+++ b/src/layouts/UseCases.tsx
@@ -189,7 +189,7 @@ export const UseCasesLayout: React.FC<IProps> = ({
           </Text>
         </BannerNotification>
       </Show>
-      <HeroContainer>
+      <HeroContainer key={frontmatter.title}>
         <TitleCard>
           <Emoji fontSize="4rem" text={frontmatter.emoji!} />
           <Title>{frontmatter.title}</Title>


### PR DESCRIPTION
## Description
- Force hero component to re-mount when title changes

## Related Issue
Fixes hero image bug when transitioning between "UseCases" pages... prevent old image from persisting temporarily while new image loads.