### PR TITLE
Fix redirect user to last page on locale change

### DIFF
--- a/src/components/Nav/useNav.ts
+++ b/src/components/Nav/useNav.ts
@@ -6,6 +6,7 @@ import { useColorMode } from "@chakra-ui/react"
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import { IItem, ISections } from "./types"
+import { FROM_QUERY } from "@/lib/constants"
 
 export const useNav = ({ path }: { path: string }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -287,8 +288,8 @@ export const useNav = ({ path }: { path: string }) => {
   const shouldShowSubNav = path.includes("/developers")
   const splitPath = path.split("/")
   const fromPageParameter =
-    splitPath.length > 3 && splitPath[2] !== "languages"
-      ? `?from=/${splitPath.slice(2).join("/")}`
+    splitPath.length > 1 && splitPath[1] !== "languages"
+      ? `?${FROM_QUERY}=/${splitPath.slice(1).join("/")}`
       : ""
 
   const changeColorMode = () => {

--- a/src/components/Nav/useNav.ts
+++ b/src/components/Nav/useNav.ts
@@ -5,8 +5,9 @@ import { useColorMode } from "@chakra-ui/react"
 
 import { trackCustomEvent } from "@/lib/utils/matomo"
 
-import { IItem, ISections } from "./types"
 import { FROM_QUERY } from "@/lib/constants"
+
+import { IItem, ISections } from "./types"
 
 export const useNav = ({ path }: { path: string }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -56,3 +56,4 @@ export const REGULAR_RATES: ReportsModel.RegularRate[] = [
 export const languagePathRootRegExp = /^.+\/content\/translations\/[a-z\-]*\//
 
 export const NAV_BAR_PX_HEIGHT = "75px"
+export const FROM_QUERY = "from"

--- a/src/pages/languages.tsx
+++ b/src/pages/languages.tsx
@@ -1,3 +1,5 @@
+import { join } from "path"
+
 import React, { useState } from "react"
 import { GetStaticProps } from "next"
 import { useRouter } from "next/router"
@@ -13,6 +15,8 @@ import {
   getRequiredNamespacesForPage,
   languages,
 } from "@/lib/utils/translations"
+
+import { FROM_QUERY } from "@/lib/constants"
 
 import Input from "../components/Input"
 import InlineLink, { BaseLink } from "../components/Link"
@@ -40,7 +44,7 @@ export const getStaticProps = (async (context) => {
 
 const LanguagesPage = () => {
   const { t } = useTranslation("page-languages")
-  const { locale } = useRouter()
+  const { locale, query } = useRouter()
 
   const [keyword, setKeyword] = useState<string>("")
   const resetKeyword = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -132,7 +136,9 @@ const LanguagesPage = () => {
           <Flex my={8} wrap="wrap" w="full">
             {translationsCompleted.map((lang) => {
               const isActive = locale === lang.code
-              const redirectTo = `/${lang.code}`
+              const fromPath =
+                FROM_QUERY in query ? (query[FROM_QUERY] as string) : ""
+              const redirectTo = `/${lang.code}` + fromPath
 
               return (
                 <LinkBox
@@ -173,7 +179,7 @@ const LanguagesPage = () => {
                     <LinkOverlay
                       as={BaseLink}
                       to={redirectTo}
-                      lang={lang.code}
+                      locale={lang.code}
                       textDecoration="none"
                       fontWeight="medium"
                       color="body.base"


### PR DESCRIPTION
## Description
- Fixes `fromPageParameter` logic when going to `/languages` page via `useNav`
- Updates `lang` prop to `locale` for `@chakra-ui/next-js` Link component usage
- Fixes `redirectTo` logic when clicking a new language inside `/languages` page
- Added a `FROM_QUERY` string constant to avoid discrepancies 

## Related Issue
Fixes [BUG-languages-page-not-redirecting-to-previous-page](https://www.notion.so/efdn/BUG-languages-page-not-redirecting-to-previous-page-e10f9276ad2b49cabc8564937ad3b036?pvs=4)