### PR TITLE
Update GitStars component

### DIFF
--- a/src/components/GitStars.tsx
+++ b/src/components/GitStars.tsx
@@ -1,39 +1,42 @@
-import React from "react"
+import { useRouter } from "next/router"
 import { FaGithub } from "react-icons/fa"
 import { Center, Flex, Icon } from "@chakra-ui/react"
 
 import Emoji from "./Emoji"
-import { BaseLink } from "./Link"
+import { BaseLink, LinkProps } from "./Link"
 import Text from "./OldText"
 
-export interface GitHubRepo {
+type GitHubRepo = {
   stargazerCount: number
   url: string
 }
 
-export interface IProps {
+type GitStarsProps = Omit<LinkProps, "to" | "href"> & {
   gitHubRepo: GitHubRepo
-  className?: string
   hideStars: boolean
 }
 
-const GitStars: React.FC<IProps> = ({ gitHubRepo, className, hideStars }) => {
-  // Stringify with commas
-  let starsString = gitHubRepo.stargazerCount.toString()
-  const rgx = /(\d+)(\d{3})/
-  while (rgx.test(starsString)) {
-    starsString = starsString.replace(rgx, "$1,$2")
-  }
+const GitStars = ({ gitHubRepo, hideStars, ...props }: GitStarsProps) => {
+  const { locale } = useRouter()
+  // Use Intl.NumberFormat to format the number for locale
+  const starsString = Intl.NumberFormat(locale, {
+    compactDisplay: "short",
+  }).format(gitHubRepo.stargazerCount)
 
   return (
-    <BaseLink className={className} to={gitHubRepo.url} hideArrow>
+    <BaseLink
+      href={gitHubRepo.url}
+      hideArrow
+      ms="auto"
+      textDecoration="none"
+      {...props}
+    >
       <Flex
         background="lightBorder"
         textDecoration="none"
         border="1px solid"
         borderColor="lightBorder"
         borderRadius="base"
-        float="inline-end"
         color="text"
         _hover={{
           boxShadow: "0 0 1px var(--eth-colors-primary-base)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,7 +66,6 @@
     "./src/components/FindWallet/WalletTable/useWalletTable.tsx",
     "./src/components/Footer.tsx",
     "./src/components/GhostCard.tsx",
-    "./src/components/GitStars.tsx",
     "./src/components/HorizontalCard.tsx",
     "./src/components/ImageCard.tsx",
     "./src/components/Input/Input.stories.tsx",


### PR DESCRIPTION
## Description
Updates the `GitStars` component
- Remove usage of `float`, replaces with `ms="auto"` on parent link
- Internationalize number formatting (remove custom "thousands" comma separation)
- Remove use of className; replace with spread `IconProps`
- Remove component from `tsconfig` exclude list

## Related Issue
https://www.notion.so/efdn/NextJS-general-QA-session-Dec-14th-cdec3085d96c4608a96b80772755f53a?pvs=4#c8a3f61d468b401ea2b0fe94af8d6b4f