### PR TITLE
Add "edit page" button back to UseCases layout banner

### DIFF
--- a/src/layouts/UseCases.tsx
+++ b/src/layouts/UseCases.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { MdExpandMore } from "react-icons/md"
 import {
@@ -21,7 +22,7 @@ import Emoji from "@/components/Emoji"
 import FeedbackCard from "@/components/FeedbackCard"
 import { Image } from "@/components/Image"
 import LeftNavBar from "@/components/LeftNavBar"
-import { BaseLink } from "@/components/Link"
+import InlineLink, { BaseLink } from "@/components/Link"
 import {
   ContentContainer,
   MobileButton,
@@ -32,6 +33,8 @@ import {
 import TableOfContents from "@/components/TableOfContents"
 
 import { getSummaryPoints } from "@/lib/utils/getSummaryPoints"
+
+import { EDIT_CONTENT_URL } from "@/lib/constants"
 
 const HeroContainer = (props: ChildOnlyProp) => (
   <Flex
@@ -87,15 +90,13 @@ export const UseCasesLayout: React.FC<IProps> = ({
   slug,
   tocItems,
 }) => {
+  const { asPath: relativePath } = useRouter()
   const { t } = useTranslation("template-usecase")
   const lgBp = useToken("breakpoints", "lg")
 
   const summaryPoints = getSummaryPoints(frontmatter)
 
-  // TODO: Re-implement GitHub edit path
-  // const { editContentUrl } = siteData.siteMetadata || {}
-  // const { relativePath } = pageContext
-  // const absoluteEditPath = `${editContentUrl}${relativePath}`
+  const absoluteEditPath = `${EDIT_CONTENT_URL}${relativePath}`
 
   // Assign hero styling, default to "defi"
   let useCase = "defi"
@@ -183,9 +184,9 @@ export const UseCasesLayout: React.FC<IProps> = ({
           <Emoji text=":pencil:" fontSize="2xl" me={4} flexShrink={0} />
           <Text m={0}>
             {t("template-usecase:template-usecase-banner")}{" "}
-            {/* <InlineLink to={absoluteEditPath}>
-              <Translation id="template-usecase-edit-link" />
-            </InlineLink> */}
+            <InlineLink href={absoluteEditPath}>
+              {t("template-usecase-edit-link")}
+            </InlineLink>
           </Text>
         </BannerNotification>
       </Show>


### PR DESCRIPTION
## Description
- Re-enables the "edit page" link for UseCases layout, following similar pattern to `Tutorial` and `Docs` layouts

## Related Issue
Fixes [missing the edit page link](https://www.notion.so/efdn/NextJS-general-QA-session-Dec-14th-cdec3085d96c4608a96b80772755f53a?pvs=4#11b0491031234a048e1c9a78ab6e5798)