### PR TITLE
Fix EthVideo component

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,15 +29,6 @@ module.exports = (phase, { defaultConfig }) => {
         test: /\.svg$/,
         use: "@svgr/webpack",
       })
-      config.module.rules.push({
-        test: /\.mp4$/,
-        use: {
-          loader: 'file-loader',
-          options: {
-            name: '[name].[ext]',
-          },
-        },
-      });
 
       return config
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@emotion/styled": "^11.11.0",
     "clipboard": "^2.0.11",
     "ethereum-blockies-base64": "^1.0.2",
-    "file-loader": "^6.2.0",
     "focus-trap-react": "^10.2.3",
     "framer-motion": "^10.13.0",
     "gray-matter": "^4.0.3",

--- a/src/components/EthVideo.tsx
+++ b/src/components/EthVideo.tsx
@@ -1,10 +1,7 @@
 import { Box, useColorModeValue } from "@chakra-ui/react"
 
-import darkVideo from "@/public/ethereum-hero-dark.mp4"
-import lightVideo from "@/public/ethereum-hero-light.mp4"
-
 const EthVideo = () => {
-  const src = useColorModeValue(lightVideo, darkVideo)
+  const src = useColorModeValue("ethereum-hero-light.mp4", "ethereum-hero-dark.mp4")
 
   return (
     <Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7841,14 +7841,6 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-loader@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 file-system-cache@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/file-system-cache/-/file-system-cache-2.3.0.tgz#201feaf4c8cd97b9d0d608e96861bb6005f46fe6"


### PR DESCRIPTION
## Description
- Removes import of `.mp4` files as components
- Pass public path to `.mp4` file as string for video `src`
- Remove `.mp4` webpack loader (previously added for this component exclusively)

## Related Issue
Fixes [video in /eth not working](https://www.notion.so/efdn/NextJS-general-QA-session-Dec-14th-cdec3085d96c4608a96b80772755f53a?pvs=4#3fbc0fed2f3f414c8d5feaedc84518a2)
