### PR TITLE
Remove PageMetadata from Docs and Tutorial layouts

### DIFF
--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -38,7 +38,6 @@ import {
   Heading4 as MdHeading4,
   Paragraph,
 } from "@/components/MdComponents"
-import PageMetadata from "@/components/PageMetadata"
 import RollupProductDevDoc from "@/components/RollupProductDevDoc"
 import SideNav from "@/components/SideNav"
 import SideNavMobile from "@/components/SideNavMobile"
@@ -234,10 +233,6 @@ export const DocsLayout = ({
 
   return (
     <Page>
-      <PageMetadata
-        title={frontmatter.title}
-        description={frontmatter.description}
-      />
       <SideNavMobile path={relativePath} />
       {isPageIncomplete && (
         <BannerNotification shouldShow={isPageIncomplete}>

--- a/src/layouts/Docs.tsx
+++ b/src/layouts/Docs.tsx
@@ -38,8 +38,7 @@ import {
   Heading4 as MdHeading4,
   Paragraph,
 } from "@/components/MdComponents"
-// TODO: IMPLEMENT PAGEMETADATA
-// import PageMetadata from "@/components/PageMetadata"
+import PageMetadata from "@/components/PageMetadata"
 import RollupProductDevDoc from "@/components/RollupProductDevDoc"
 import SideNav from "@/components/SideNav"
 import SideNavMobile from "@/components/SideNavMobile"
@@ -235,11 +234,10 @@ export const DocsLayout = ({
 
   return (
     <Page>
-      {/* // TODO: IMPLEMENT PAGEMETADATA */}
-      {/* <PageMetadata
+      <PageMetadata
         title={frontmatter.title}
         description={frontmatter.description}
-      /> */}
+      />
       <SideNavMobile path={relativePath} />
       {isPageIncomplete && (
         <BannerNotification shouldShow={isPageIncomplete}>

--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -16,8 +16,6 @@ import {
 import type { ChildOnlyProp, TranslationKey } from "@/lib/types"
 import type { MdPageContent, TutorialFrontmatter } from "@/lib/interfaces"
 
-// TODO: Import once intl implements?
-// import PageMetadata from "@/components/PageMetadata"
 import PostMergeBanner from "@/components/Banners/PostMergeBanner"
 // Components
 import { ButtonLink } from "@/components/Buttons"
@@ -38,6 +36,7 @@ import {
   Heading4 as MdHeading4,
 } from "@/components/MdComponents"
 import MdLink from "@/components/MdLink"
+import PageMetadata from "@/components/PageMetadata"
 import { mdxTableComponents } from "@/components/Table"
 import TableOfContents from "@/components/TableOfContents"
 import TutorialMetadata from "@/components/TutorialMetadata"
@@ -211,12 +210,11 @@ export const TutorialLayout = ({
         p={{ base: "0", lg: "0 2rem 0 0" }}
         background={{ base: "background.base", lg: "ednBackground" }}
       >
-        {/* TODO: Implement PageMetaData after intl */}
-        {/* <PageMetadata
+        <PageMetadata
           title={frontmatter.title}
           description={frontmatter.description}
           canonicalUrl={frontmatter.sourceUrl}
-        /> */}
+        />
         <ContentContainer>
           <Heading1>{frontmatter.title}</Heading1>
           <TutorialMetadata frontmatter={frontmatter} timeToRead={timeToRead} />

--- a/src/layouts/Tutorial.tsx
+++ b/src/layouts/Tutorial.tsx
@@ -36,7 +36,6 @@ import {
   Heading4 as MdHeading4,
 } from "@/components/MdComponents"
 import MdLink from "@/components/MdLink"
-import PageMetadata from "@/components/PageMetadata"
 import { mdxTableComponents } from "@/components/Table"
 import TableOfContents from "@/components/TableOfContents"
 import TutorialMetadata from "@/components/TutorialMetadata"
@@ -210,11 +209,6 @@ export const TutorialLayout = ({
         p={{ base: "0", lg: "0 2rem 0 0" }}
         background={{ base: "background.base", lg: "ednBackground" }}
       >
-        <PageMetadata
-          title={frontmatter.title}
-          description={frontmatter.description}
-          canonicalUrl={frontmatter.sourceUrl}
-        />
         <ContentContainer>
           <Heading1>{frontmatter.title}</Heading1>
           <TutorialMetadata frontmatter={frontmatter} timeToRead={timeToRead} />


### PR DESCRIPTION
## Description
~~Re-enable PageMetadata for Docs and Tutorial layouts~~

Realizing we already handle `PageMetadata` within `[...slug]`; re-using within the `Docs` and `Tutorial` templates is redundant and not necessary.

- Removes `PageMetadata` from `Docs` and `Tutorial` templates
