### PR TITLE
Fix flipForRtl usage on inline items

### DIFF
--- a/src/components/EthPriceCard.tsx
+++ b/src/components/EthPriceCard.tsx
@@ -170,6 +170,7 @@ const EthPriceCard = ({ isLeftAlign = false, ...props }: EthPriceCardProps) => {
             _after={{
               content: isNegativeChange ? '"↘"' : '"↗"',
               transform: flipForRtl,
+              display: "inline-block",
             }}
           >
             {change}

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -130,8 +130,9 @@ const Leaderboard = ({ content, limit = 100 }: LeaderboardProps) => {
                     ms: 0.5,
                     me: 1.5,
                     transform: flipForRtl,
+                    display: "inline-block",
                   }}
-                ></Box>
+                />
               </LinkBox>
             </ListItem>
           )

--- a/src/components/MeetupList.tsx
+++ b/src/components/MeetupList.tsx
@@ -139,6 +139,7 @@ const MeetupList: React.FC<IProps> = () => {
                 ms: 0.5,
                 me: 1.5,
                 transform: flipForRtl,
+                display: "inline-block",
               }}
             ></Box>
           </LinkBox>

--- a/src/components/SimpleTable.tsx
+++ b/src/components/SimpleTable.tsx
@@ -62,7 +62,7 @@ const SimpleTable: React.FC<IProps> = ({ columns, content, hasError }) => {
 
           {content && content[0]?.url && (
             <Th p={5} fontSize="md" fontWeight="normal" textAlign="end">
-              <Text as="span" transform={flipForRtl}>
+              <Text as="span" display="inline-block" transform={flipForRtl}>
                 ↗
               </Text>
             </Th>


### PR DESCRIPTION
## Description
Adds `display: "inline-block"` to otherwise "inline" items that require horizontal flipping for RTL locales

## Related Issue
https://www.notion.so/efdn/NextJS-general-QA-session-Dec-14th-cdec3085d96c4608a96b80772755f53a?pvs=4#6eb04505f95f4e3e85621e7305c7d57c

## Preview link
https://deploy-preview-208--ethereum-org-fork.netlify.app/ar/eth
https://deploy-preview-208--ethereum-org-fork.netlify.app/ar/community/events
https://deploy-preview-208--ethereum-org-fork.netlify.app/ar/bug-bounty