### PR TITLE
Update and enable Search component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,20 @@
 # rename this file to .env and supply the values listed below
 # also make sure they are available to the build tool (e.g. Netlify)
-# warning: variables prefixed with GATSBY_ will be made available to client-side code
+# warning: variables prefixed with NEXT_PUBLIC_ will be made available to client-side code
 # be careful not to expose sensitive data (e.g. your Algolia admin key)
-# ALGOLIA_ADMIN_KEY=insertValue
-# ETHERSCAN_API_KEY=insertValue
-# GATSBY_ALGOLIA_APP_ID=insertValue
-# GATSBY_ALGOLIA_SEARCH_KEY=insertValue
-# GATSBY_ALGOLIA_BASE_SEARCH_INDEX_NAME=insertValue
-NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY=insertValue
-# GATSBY_FUNCTIONS_PATH=insertValue
 
-# Folders or files to ignore from the `public/content` folder
-IGNORE_CONTENT=**/docs,**/tutorials
+# Algolia environment (app ID, search key and base search index name required for search)
+# NEXT_PUBLIC_ALGOLIA_APP_ID=insertValue
+# NEXT_PUBLIC_ALGOLIA_SEARCH_KEY=insertValue
+# NEXT_PUBLIC_ALGOLIA_BASE_SEARCH_INDEX_NAME=insertValue
+# NEXT_PUBLIC_GITHUB_TOKEN_READ_ONLY=insertValue
+
+# Etherscan API key (required for Etherscan API fetches)
+# ETHERSCAN_API_KEY=insertValue
+
+# Google API key and Calendar ID (required to fetch Calendar events)
+# GOOGLE_API_KEY=
+# GOOGLE_CALENDAR_ID=
 
 # Used to avoid loading Matomo in our preview deploys
 IS_PREVIEW_DEPLOY=false

--- a/src/lib/utils/sanitizeHitTitle.ts
+++ b/src/lib/utils/sanitizeHitTitle.ts
@@ -1,0 +1,1 @@
+export const sanitizeHitTitle = (value: string): string => value.split(" | ")[0]


### PR DESCRIPTION
## Description
- Implements Search component powered by DocSearch and Algolia
- Migrates/updates `sanitizeHitTitle`—no longer needs checks for escaped character (`&apos;`, etc)
- Update `.env.example` using `NEXT_PUBLIC_` prefix; remove deprecated variables, add some comments (env vars updated in Netlify as well)

## Related Issue
https://www.notion.so/efdn/Implement-search-functionality-bb7988a4cc8c4de6b42c4797b02d2269?pvs=4