### PR TITLE
Fix i18n strings in SideNavMobile component

### DIFF
--- a/src/components/SideNavMobile.tsx
+++ b/src/components/SideNavMobile.tsx
@@ -154,15 +154,10 @@ const SideNavMobile: React.FC<IProps> = ({ path }) => {
 
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
-  // Strip language path
-  let pagePath = path
-  if (isLang(pagePath.split("/")[1])) {
-    pagePath = pagePath.substring(3)
-  }
-  let pageTitleId = getPageTitleId(pagePath, docLinks)
-  if (!pageTitleId) {
-    pageTitleId = `Change page` as TranslationKey
-  }
+  // Add trailing slash to path for docLinks match
+  const pageTitleId =
+    getPageTitleId(path + "/", docLinks) || ("Change page" as TranslationKey)
+
   return (
     <Box
       position="sticky"

--- a/src/components/SideNavMobile.tsx
+++ b/src/components/SideNavMobile.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useState } from "react"
 import { AnimatePresence, motion } from "framer-motion"
+import { useTranslation } from "next-i18next"
 import { MdExpandMore } from "react-icons/md"
 import { Box, Center, HStack, Icon } from "@chakra-ui/react"
 
@@ -7,9 +8,6 @@ import type { TranslationKey } from "@/lib/types"
 import { DeveloperDocsLink } from "@/lib/interfaces"
 
 import { BaseLink, LinkProps } from "@/components/Link"
-import Translation from "@/components/Translation"
-
-import { isLang } from "@/lib/utils/translations"
 
 import docLinks from "@/data/developer-docs-links.yaml"
 
@@ -90,6 +88,7 @@ export interface IPropsNavLink extends INavLinkProps {
 }
 
 const NavLink: React.FC<IPropsNavLink> = ({ item, path, toggle }) => {
+  const { t } = useTranslation("page-developers-docs")
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   if (item.items) {
@@ -98,12 +97,12 @@ const NavLink: React.FC<IPropsNavLink> = ({ item, path, toggle }) => {
         <LinkContainer>
           {item.to && (
             <SideNavLink to={item.to} isPartiallyActive={false}>
-              <Translation id={item.id} />
+              {t(item.id)}
             </SideNavLink>
           )}
           {!item.to && (
             <Box w="full" cursor="pointer" onClick={() => setIsOpen(!isOpen)}>
-              <Translation id={item.id} />
+              {t(item.id)}
             </Box>
           )}
           <Box
@@ -138,7 +137,7 @@ const NavLink: React.FC<IPropsNavLink> = ({ item, path, toggle }) => {
     <Box onClick={toggle}>
       <LinkContainer>
         <SideNavLink to={item.to} isPartiallyActive={false}>
-          <Translation id={item.id} />
+          {t(item.id)}
         </SideNavLink>
       </LinkContainer>
     </Box>
@@ -151,6 +150,8 @@ export interface IProps {
 
 // TODO consolidate into SideNav
 const SideNavMobile: React.FC<IProps> = ({ path }) => {
+  const { t } = useTranslation("page-developers-docs")
+
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   // Strip language path
@@ -185,9 +186,7 @@ const SideNavMobile: React.FC<IProps> = ({ path }) => {
         borderBottomColor="border"
         onClick={() => setIsOpen(!isOpen)}
       >
-        <Box me={2}>
-          <Translation id={pageTitleId} />
-        </Box>
+        <Box me={2}>{t(pageTitleId)}</Box>
         <Box
           as={motion.div}
           cursor="pointer"


### PR DESCRIPTION
## Description
- Updates `SideNavMobile` component to use `useTranslation` hook, fixes namespace issue
- Update logic for `pageTitleId` in same component: We no longer need to strip out the language, since the `path` prop originates from `router.asPath`. We currently need to add a trailing slash for this to match against the `to` values inside `developer-docs-links.yaml`

## Preview link
- https://deploy-preview-215--ethereum-org-fork.netlify.app/developers/docs/blocks

## Related Issue
example: https://ethereum-org-fork.netlify.app/es/developers/docs/blocks
<img width="472" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/0d6a6b9a-6152-4266-a909-6def0d445b93">

PR:
<img width="608" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/2ff92387-a7bc-4b6f-8e3f-f0b47730c764">
