### PR TITLE
Fix focus state for auto-linked headings

### DIFF
--- a/src/components/MdComponents.tsx
+++ b/src/components/MdComponents.tsx
@@ -43,15 +43,15 @@ import InfoBanner from "./InfoBanner"
 /**
  * Base HTML elements
  */
-const headingPropsForAnchor = (id?: string): HeadingProps =>
-  id
-    ? ({
-        scrollMarginTop: 28,
-        id,
-        "data-group": true,
-        position: "relative",
-      } as HeadingProps)
-    : {}
+const headingPropsForAnchor = (id?: string): HeadingProps => {
+  if (!id) return {}
+  return {
+    scrollMarginTop: 28,
+    id,
+    "data-group": true,
+    position: "relative",
+  } as HeadingProps
+}
 
 export const commonHeadingProps = (id?: string): HeadingProps => ({
   fontWeight: 700,
@@ -59,24 +59,23 @@ export const commonHeadingProps = (id?: string): HeadingProps => ({
   ...headingPropsForAnchor(id),
 })
 
-const IdAnchor: React.FC<{ id?: string }> = ({ id }) =>
-  id ? (
+const IdAnchor: React.FC<{ id?: string }> = ({ id }) => {
+  if (!id) return null
+  return (
     <Link
-      href={`#${id}`}
+      href={"#" + id}
       position="absolute"
       insetInlineEnd="100%"
       aria-label={id.replaceAll("-", " ") + " permalink"}
+      opacity={0}
+      _groupHover={{ opacity: 1 }}
+      _focus={{ opacity: 1 }}
+      transition="opacity 0.1s ease-in-out"
     >
-      <Icon
-        as={CiLink}
-        opacity={0}
-        _groupHover={{ opacity: 1 }}
-        transition="opacity 0.1s ease-in-out"
-        fontSize="xl"
-        me={1}
-      />
+      <Icon as={CiLink} fontSize="xl" me="1" />
     </Link>
-  ) : null
+  )
+}
 
 export const Heading1 = ({ children, ...rest }: HeadingProps) => (
   <OldHeading as="h1" {...commonHeadingProps()} fontSize="2.5rem" {...rest}>


### PR DESCRIPTION
## Description
Fix keyboard focus state for `IdAnchor` inside `MdComponents`

- Move opacity styling to Link and add _focus state with opacity 1
- Patches nested logic, switching to guard clause syntax

## Related Issue
- Fixes link icon not displaying on keyboard focus

<img width="638" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/2096dddb-dfdb-4155-b6b0-b1ddd3dcfc48">

With PR:

<img width="744" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/075c1470-00b7-4c61-ab46-717d6d8a927e">
