### PR TITLE
Fix: CTA label rendering inside ProductList component

### DIFF
--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -10,7 +10,6 @@ import {
 import { ButtonLink } from "@/components/Buttons"
 import { Image, type ImageProps } from "@/components/Image"
 import OldHeading from "@/components/OldHeading"
-import Translation from "@/components/Translation"
 
 type Content = {
   title: string
@@ -21,12 +20,13 @@ type Content = {
   id?: string
 }
 
-type ProductListProps = {
+export type ProductListProps = {
   content: Content[]
   category: string
+  actionLabel: string
 }
 
-const ProductList = ({ content, category }: ProductListProps) => {
+const ProductList = ({ actionLabel, content, category }: ProductListProps) => {
   const shadow = useColorModeValue("tableBox.light", "tableBox.dark")
 
   const CATEGORY_NAME = "category-name"
@@ -89,7 +89,7 @@ const ProductList = ({ content, category }: ProductListProps) => {
               {link && (
                 <ButtonLink
                   variant="outline"
-                  to={link}
+                  href={link}
                   alignSelf="center"
                   ms={{ base: 0, sm: 8 }}
                   paddingY={1}
@@ -97,7 +97,7 @@ const ProductList = ({ content, category }: ProductListProps) => {
                   borderRadius="sm"
                   marginTop={{ base: 4, sm: 0 }}
                 >
-                  <Translation id="page-layer-2:page-dapps-ready-button" />
+                  {actionLabel}
                   <VisuallyHidden>to {title} website</VisuallyHidden>
                 </ButtonLink>
               )}

--- a/src/pages/dapps.tsx
+++ b/src/pages/dapps.tsx
@@ -38,7 +38,9 @@ import Text from "@/components/OldText"
 import PageHero from "@/components/PageHero"
 import PageMetadata from "@/components/PageMetadata"
 import ProductCard from "@/components/ProductCard"
-import ProductList from "@/components/ProductList"
+import ProductListComponent, {
+  type ProductListProps,
+} from "@/components/ProductList"
 
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { trackCustomEvent } from "@/lib/utils/matomo"
@@ -387,6 +389,16 @@ const StyledCardGrid = (props: ChildOnlyProp) => (
 const MoreButtonContainer = (props: ChildOnlyProp) => (
   <Flex justify="center" mt={12} mb={4} {...props} />
 )
+
+const ProductList = (props: Omit<ProductListProps, "actionLabel">) => {
+  const { t } = useTranslation("page-dapps")
+  return (
+    <ProductListComponent
+      actionLabel={t("page-dapps-ready-button")}
+      {...props}
+    />
+  )
+}
 
 enum CategoryType {
   FINANCE = "finance",

--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -39,9 +39,7 @@ import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 import { layer2Data } from "@/data/layer-2/layer-2"
 
 import Layer2Onboard from "../components/Layer2/Layer2Onboard"
-import ProductListComponent, {
-  ProductListProps,
-} from "../components/ProductList"
+import ProductList from "../components/ProductList"
 
 import DogeImage from "@/public/doge-computer.png"
 import EthHomeImage from "@/public/eth-home-icon.png"
@@ -105,16 +103,6 @@ const Layer2CardGrid = (props) => (
     {...props}
   />
 )
-
-const ProductList = (props: Omit<ProductListProps, "actionLabel">) => {
-  const { t } = useTranslation("page-dapps")
-  return (
-    <ProductListComponent
-      actionLabel={t("page-dapps-ready-button")}
-      {...props}
-    />
-  )
-}
 
 type Props = SSRConfig & {
   lastDeployDate: string
@@ -603,12 +591,14 @@ const Layer2Page = () => {
             <ProductList
               category="Information"
               content={toolsData.information}
+              actionLabel={t("page-dapps-ready-button")}
             />
           </Box>
           <Box flex="50%">
             <ProductList
               category="Wallet managers"
               content={toolsData.walletManagers}
+              actionLabel={t("page-dapps-ready-button")}
             />
           </Box>
         </TwoColumnContent>

--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -39,7 +39,9 @@ import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 import { layer2Data } from "@/data/layer-2/layer-2"
 
 import Layer2Onboard from "../components/Layer2/Layer2Onboard"
-import ProductList from "../components/ProductList"
+import ProductListComponent, {
+  ProductListProps,
+} from "../components/ProductList"
 
 import DogeImage from "@/public/doge-computer.png"
 import EthHomeImage from "@/public/eth-home-icon.png"
@@ -103,6 +105,16 @@ const Layer2CardGrid = (props) => (
     {...props}
   />
 )
+
+const ProductList = (props: Omit<ProductListProps, "actionLabel">) => {
+  const { t } = useTranslation("page-dapps")
+  return (
+    <ProductListComponent
+      actionLabel={t("page-dapps-ready-button")}
+      {...props}
+    />
+  )
+}
 
 type Props = SSRConfig & {
   lastDeployDate: string


### PR DESCRIPTION
## Description
`ProductList` component used on multiple pages, each with different namespaces loaded.

Currently consumed by `/layer-2/` and `/dapps/` pages. The key `page-dapps-ready-button` exists in both `page-dapps.json` and `page-layer-2.json` but only one of these namespaces is loaded for each page. Hard-coding `page-layer-2:page-dapps-ready-button` means that this string won't load on the `/dapps` page; visa verse if you switch to `page-dapps:page-dapps-ready-button`.

- This PR passes the resolved string directly from the parent pages to `ProductList.tsx`
- Extracts logic into local reusable component for `/dapps` page given significant usage of this component on that page

## Related Issue
Fixes i18n strings showing for "Go" button on [dapps] page(https://ethereum-org-fork.netlify.app/dapps).

<img width="1206" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/8efc6cf8-1bae-40d2-96b9-f41286dcd42d">

## Note
This component is also used once inside the `/stablecoins` page which has not been migrated yet. This string is already located in the `page-stablecoins.json` file and would just need `actionLabel={t("page-dapps-ready-button")}` added to the `<ProductList />` props 