### PR TITLE
Ignore locale for image links

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -121,9 +121,30 @@ export const BaseLink = forwardRef(function Link(
     )
   }
 
+  if (imageLink) {
+    return (
+      <NextLink
+        onClick={() =>
+          trackCustomEvent(
+            customEventOptions ?? {
+              eventCategory: `Link`,
+              eventAction: `Clicked`,
+              eventName: `Clicked on image link`,
+              eventValue: href,
+            }
+          )
+        }
+        hrefLang=""
+        {...commonProps}
+      >
+        {children}
+      </NextLink>
+    )
+  }
+
   return (
     <NextLink
-      locale={imageLink ? false : locale} // dont use locale in next if its a local image
+      locale={locale}
       onClick={() =>
         trackCustomEvent(
           customEventOptions ?? {

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -123,7 +123,7 @@ export const BaseLink = forwardRef(function Link(
 
   return (
     <NextLink
-      locale={imageLink ? undefined : locale} // dont use locale in next if its a local image
+      locale={imageLink ? false : locale} // dont use locale in next if its a local image
       onClick={() =>
         trackCustomEvent(
           customEventOptions ?? {

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -28,6 +28,7 @@ type BaseProps = {
   isPartiallyActive?: boolean
   activeStyle?: StyleProps
   customEventOptions?: MatomoEventOptions
+  imageLink?: boolean
 }
 
 export type LinkProps = BaseProps & Omit<NextLinkProps, "href">
@@ -53,6 +54,7 @@ export const BaseLink = forwardRef(function Link(
     isPartiallyActive = true,
     activeStyle = { color: "primary.base" },
     customEventOptions,
+    imageLink,
     ...props
   }: LinkProps,
   ref
@@ -121,7 +123,7 @@ export const BaseLink = forwardRef(function Link(
 
   return (
     <NextLink
-      locale={locale}
+      locale={imageLink ? undefined : locale} // dont use locale in next if its a local image
       onClick={() =>
         trackCustomEvent(
           customEventOptions ?? {

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -123,7 +123,7 @@ export const BaseLink = forwardRef(function Link(
 
   if (imageLink) {
     return (
-      <NextLink
+      <ChakraLink
         onClick={() =>
           trackCustomEvent(
             customEventOptions ?? {
@@ -134,11 +134,10 @@ export const BaseLink = forwardRef(function Link(
             }
           )
         }
-        hrefLang=""
         {...commonProps}
       >
         {children}
-      </NextLink>
+      </ChakraLink>
     )
   }
 

--- a/src/components/MarkdownImage.tsx
+++ b/src/components/MarkdownImage.tsx
@@ -37,13 +37,13 @@ const MarkdownImage = ({
   }
 
   const fileExt = extname(transformedSrc).toLowerCase()
-  const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)  
+  const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)
 
   return (
     // display the wrapper as a `span` to avoid dom nesting warnings as mdx
     // sometimes wraps images in `p` tags
     <Flex as="span" justify="center">
-      <Link href={transformedSrc} target="_blank" rel="noopener">
+      <Link href={transformedSrc} target="_blank" rel="noopener" imageLink>
         <Image
           alt={alt}
           width={imageWidth}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add bool prop imageLink as props for Link
- Add logic for when imageLink is true, ignore prepending locale in NextLink
- Add imageLink to MarkdownImage

## Related Issue

https://www.notion.so/efdn/BUG-clicking-on-translated-images-fails-aea3e22c7ea94d68ae50fc084911a3d4
