### PR TITLE
Netlify build function size

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,7 +19,7 @@
 
 [functions]
   included_files = [
-    "!./src/data/**/*",
+    "./src/intl/**/*",
     "!./public/**/*",
-    
+    "!./node_modules/@swc/core-linux-x64-musl/**/*",
   ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ignores an internal swc package as a temporary fix to reduce the bundle size for the deployed Netlify functions.
