### PR TITLE
Fix data fetching errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,6 @@ IS_PREVIEW_DEPLOY=false
 # Note: always include `en` as it is the default lang of the site
 BUILD_LOCALES=
 
-# If resource constraints are being hit during builds, change LIMIT_CPU to `true`
-# to limit the demand during build time
-LIMIT_CPU=false
+# If resource constraints are being hit during builds, change LIMIT_CPUS to a
+# fixed number of CPUs (e.g. 2) to limit the demand during build time
+LIMIT_CPUS=

--- a/next.config.js
+++ b/next.config.js
@@ -2,18 +2,19 @@ const { PHASE_DEVELOPMENT_SERVER } = require("next/constants")
 
 const { i18n } = require("./next-i18next.config")
 
-const experimental =
-  (process.env.LIMIT_CPU || "").toLowerCase() === "true"
-    ? {
-        // This option could be enabled in the future when flagged as stable, to speed up builds
-        // (see https://nextjs.org/docs/pages/building-your-application/configuring/mdx#using-the-rust-based-mdx-compiler-experimental)
-        // mdxRs: true,
+const LIMIT_CPUS = Number(process.env.LIMIT_CPUS || 2)
 
-        // Reduce the number of cpus and disable parallel threads in prod envs to consume less memory
-        workerThreads: false,
-        cpus: 2,
-      }
-    : {}
+const experimental = LIMIT_CPUS
+  ? {
+      // This option could be enabled in the future when flagged as stable, to speed up builds
+      // (see https://nextjs.org/docs/pages/building-your-application/configuring/mdx#using-the-rust-based-mdx-compiler-experimental)
+      // mdxRs: true,
+
+      // Reduce the number of cpus and disable parallel threads in prod envs to consume less memory
+      workerThreads: false,
+      cpus: LIMIT_CPUS,
+    }
+  : {}
 
 /** @type {import('next').NextConfig} */
 module.exports = (phase, { defaultConfig }) => {

--- a/src/lib/api/calendarEvents.ts
+++ b/src/lib/api/calendarEvents.ts
@@ -10,17 +10,19 @@ export async function fetchCommunityEvents(): Promise<CommunityEventsReturnType>
   const calendarId = process.env.GOOGLE_CALENDAR_ID
 
   try {
-    const futureEventsReq: ReqCommunityEvent[] = await fetch(
+    const futureEventsReq = await fetch(
       `https://content.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${apiKey}&timeMin=${new Date().toISOString()}&maxResults=3`
-    ).then(response => response.json())
-    .then(data => data.items)
+    )
+    const futureEvents = await futureEventsReq.json()
+    const futureEventsReqData: ReqCommunityEvent[] = futureEvents.items
 
-    const pastEventsReq: ReqCommunityEvent[] = await fetch(
+    const pastEventsReq = await fetch(
       `https://content.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${apiKey}&timeMax=${new Date().toISOString()}&maxResults=4`
-    ).then(response => response.json())
-    .then(data => data.items)
+    )
+    const pastEvents = await pastEventsReq.json()
+    const pastEventsReqData: ReqCommunityEvent[] = pastEvents.items
 
-    const pastEventData = pastEventsReq.map((event) => {
+    const pastEventData = pastEventsReqData.map((event) => {
       return {
         date: event.start.dateTime,
         title: event.summary,
@@ -28,7 +30,7 @@ export async function fetchCommunityEvents(): Promise<CommunityEventsReturnType>
         pastEventLink: event.location,
       }
     })
-    const upcomingEventData = futureEventsReq.map((event) => {
+    const upcomingEventData = futureEventsReqData.map((event) => {
       return {
         date: event.start.dateTime,
         title: event.summary,

--- a/src/lib/api/fetchNodes.ts
+++ b/src/lib/api/fetchNodes.ts
@@ -1,4 +1,8 @@
-import type { EtherscanNodeResponse, MetricReturnData, TimestampedData } from "@/lib/types"
+import type {
+  EtherscanNodeResponse,
+  MetricReturnData,
+  TimestampedData,
+} from "@/lib/types"
 
 import { DAYS_TO_FETCH, ETHERSCAN_API_URL } from "@/lib/constants"
 
@@ -23,13 +27,18 @@ export const fetchNodes = async (): Promise<MetricReturnData> => {
 
   try {
     const response = await fetch(href)
-    if (!response.ok) throw new Error("Failed to fetch Etherscan node data")
+    if (!response.ok) {
+      console.log(response.status, response.statusText)
+      throw new Error("Failed to fetch Etherscan node data")
+    }
 
     const json: EtherscanNodeResponse = await response.json()
-    const data: TimestampedData<number>[] = json.result.map(({ UTCDate, TotalNodeCount }) => ({
-      timestamp: new Date(UTCDate).getTime(),
-      value: +TotalNodeCount,
-    })).sort((a, b) => a.timestamp - b.timestamp)
+    const data: TimestampedData<number>[] = json.result
+      .map(({ UTCDate, TotalNodeCount }) => ({
+        timestamp: new Date(UTCDate).getTime(),
+        value: +TotalNodeCount,
+      }))
+      .sort((a, b) => a.timestamp - b.timestamp)
     const { value } = data[data.length - 1]
 
     return {

--- a/src/lib/api/fetchTotalEthStaked.ts
+++ b/src/lib/api/fetchTotalEthStaked.ts
@@ -1,4 +1,8 @@
-import type { EthStoreResponse, MetricReturnData, TimestampedData } from "@/lib/types"
+import type {
+  EthStoreResponse,
+  MetricReturnData,
+  TimestampedData,
+} from "@/lib/types"
 
 import { weiToRoundedEther } from "@/lib/utils/weiToRoundedEther"
 
@@ -8,31 +12,52 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24
 const DAY_DELTA = 5
 
 export const fetchTotalEthStaked = async (): Promise<MetricReturnData> => {
-  const { href: ethstoreLatest } = new URL("api/v1/ethstore/latest", BEACONCHA_IN_URL)
+  const { href: ethstoreLatest } = new URL(
+    "api/v1/ethstore/latest",
+    BEACONCHA_IN_URL
+  )
 
   try {
     // 1- Use initial call to `latest` to fetch current Beacon Chain "day" (for use in secondary fetches)
     const ethstoreLatestResponse = await fetch(ethstoreLatest)
-    if (!ethstoreLatestResponse.ok) throw new Error("Failed to fetch Ethstore latest data")
+    if (!ethstoreLatestResponse.ok) {
+      console.log(
+        ethstoreLatestResponse.status,
+        ethstoreLatestResponse.statusText
+      )
+      throw new Error("Failed to fetch Ethstore latest data")
+    }
 
     const ethstoreJson: EthStoreResponse = await ethstoreLatestResponse.json()
-    const { data: { day, effective_balances_sum_wei } } = ethstoreJson
+    const {
+      data: { day, effective_balances_sum_wei },
+    } = ethstoreJson
     const valueTotalEth = weiToRoundedEther(effective_balances_sum_wei)
 
-    const data: TimestampedData<number>[] = [{ timestamp: new Date().getTime(), value: valueTotalEth }]
+    const data: TimestampedData<number>[] = [
+      { timestamp: new Date().getTime(), value: valueTotalEth },
+    ]
 
     // 2- Perform multiple API calls to fetch data for the last 90 days, `getData` for caching
     for (let i = DAY_DELTA; i <= DAYS_TO_FETCH; i += DAY_DELTA) {
       const lookupDay = day - i
       const timestamp = new Date().getTime() - i * MS_PER_DAY
 
-      const { href: ethstoreDay } = new URL(`api/v1/ethstore/${lookupDay}`, BEACONCHA_IN_URL)
+      const { href: ethstoreDay } = new URL(
+        `api/v1/ethstore/${lookupDay}`,
+        BEACONCHA_IN_URL
+      )
 
       const ethstoreDayResponse = await fetch(ethstoreDay)
-      if (!ethstoreDayResponse.ok) throw new Error("Failed to fetch Ethstore day data")
+      if (!ethstoreDayResponse.ok) {
+        console.log(ethstoreDayResponse.status, ethstoreDayResponse.statusText)
+        throw new Error("Failed to fetch Ethstore day data")
+      }
 
       const ethstoreDayJson: EthStoreResponse = await ethstoreDayResponse.json()
-      const { data: { effective_balances_sum_wei: sumWei } } = ethstoreDayJson
+      const {
+        data: { effective_balances_sum_wei: sumWei },
+      } = ethstoreDayJson
       const value = weiToRoundedEther(sumWei)
 
       data.push({ timestamp, value })

--- a/src/lib/api/fetchTotalValueLocked.ts
+++ b/src/lib/api/fetchTotalValueLocked.ts
@@ -11,16 +11,18 @@ export const fetchTotalValueLocked = async (): Promise<MetricReturnData> => {
 
   try {
     const response = await fetch(`https://api.llama.fi/charts/Ethereum`)
-    if (!response.ok) throw new Error("Failed to fetch Defi Llama TVL data")
+    if (!response.ok) {
+      console.log(response.status, response.statusText)
+      throw new Error("Failed to fetch Defi Llama TVL data")
+    }
 
     const json: DefiLlamaTVLResponse = await response.json()
-    const data = takeRightWhile(
-      json,
-      ({ date }) => +date > startTimestamp
-    ).map(({ date, totalLiquidityUSD }) => ({
-      timestamp: +date * 1000,
-      value: totalLiquidityUSD,
-    })).sort((a, b) => a.timestamp - b.timestamp)
+    const data = takeRightWhile(json, ({ date }) => +date > startTimestamp)
+      .map(({ date, totalLiquidityUSD }) => ({
+        timestamp: +date * 1000,
+        value: totalLiquidityUSD,
+      }))
+      .sort((a, b) => a.timestamp - b.timestamp)
     const { value } = data[data.length - 1]
 
     return {

--- a/src/lib/api/fetchTxCount.ts
+++ b/src/lib/api/fetchTxCount.ts
@@ -1,4 +1,8 @@
-import type { EtherscanTxCountResponse, MetricReturnData, TimestampedData } from "@/lib/types"
+import type {
+  EtherscanTxCountResponse,
+  MetricReturnData,
+  TimestampedData,
+} from "@/lib/types"
 
 import { DAYS_TO_FETCH, ETHERSCAN_API_URL } from "@/lib/constants"
 
@@ -23,13 +27,18 @@ export const fetchTxCount = async (): Promise<MetricReturnData> => {
 
   try {
     const response = await fetch(href)
-    if (!response.ok) throw new Error("Failed to fetch Etherscan tx count data")
+    if (!response.ok) {
+      console.log(response.status, response.statusText)
+      throw new Error("Failed to fetch Etherscan tx count data")
+    }
 
     const json: EtherscanTxCountResponse = await response.json()
-    const data: TimestampedData<number>[] = json.result.map(({ unixTimeStamp, transactionCount }) => ({
-      timestamp: +unixTimeStamp * 1000, // unix milliseconds
-      value: transactionCount,
-    })).sort((a, b) => a.timestamp - b.timestamp)
+    const data: TimestampedData<number>[] = json.result
+      .map(({ unixTimeStamp, transactionCount }) => ({
+        timestamp: +unixTimeStamp * 1000, // unix milliseconds
+        value: transactionCount,
+      }))
+      .sort((a, b) => a.timestamp - b.timestamp)
     const { value } = data[data.length - 1]
 
     return {
@@ -39,7 +48,7 @@ export const fetchTxCount = async (): Promise<MetricReturnData> => {
   } catch (error: unknown) {
     console.error((error as Error).message)
     return {
-      error: (error as Error).message
+      error: (error as Error).message,
     }
   }
 }

--- a/src/lib/api/ghRepoData.ts
+++ b/src/lib/api/ghRepoData.ts
@@ -1,6 +1,6 @@
-import axios from 'axios'
+import axios from "axios"
 
-import { Framework } from '@/lib/interfaces'
+import { Framework } from "@/lib/interfaces"
 
 import EthDiamondBlackImage from "@/public/assets/eth-diamond-black.png"
 import EpirusImage from "@/public/dev-tools/epirus.png"
@@ -128,12 +128,26 @@ export const ghRepoData = async (githubUrl: string) => {
   const split = githubUrl.split("/")
   const repoOwner = split[split.length - 2]
   const repoName = split[split.length - 1]
-  const repoData = await axios.get(`https://api.github.com/repos/${repoOwner}/${repoName}`, { headers: { 'Authorization': `Bearer ${process.env.GITHUB_TOKEN_READ_ONLY}` }}) 
-const languageData = await axios.get(`https://api.github.com/repos/${repoOwner}/${repoName}/languages`, { headers: { 'Authorization': `Bearer ${process.env.GITHUB_TOKEN_READ_ONLY}` }})
-    return {
-        starCount: repoData.data.stargazers_count,
-        languages: Object.keys(languageData.data),
+  const repoData = await axios.get(
+    `https://api.github.com/repos/${repoOwner}/${repoName}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN_READ_ONLY}`,
+      },
     }
+  )
+  const languageData = await axios.get(
+    `https://api.github.com/repos/${repoOwner}/${repoName}/languages`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN_READ_ONLY}`,
+      },
+    }
+  )
+  return {
+    starCount: repoData.data.stargazers_count,
+    languages: Object.keys(languageData.data),
+  }
 }
 
 export const getLocalEnvironmentFrameworkData = async () => {

--- a/src/lib/api/stablecoinsData.ts
+++ b/src/lib/api/stablecoinsData.ts
@@ -6,7 +6,12 @@ export async function fetchEthereumEcosystemData() {
   try {
     const res = await fetch(url)
 
-    return res.json()
+    if (!res.ok) {
+      console.log(res.status, res.statusText)
+      throw new Error("Failed to fetch Ethereum ecosystem data")
+    }
+
+    return await res.json()
   } catch (error) {
     // In production mode, throw an error to stop the build in case this fetch fails
     console.error(error)
@@ -22,7 +27,12 @@ export async function fetchEthereumStablecoinsData() {
   try {
     const res = await fetch(url)
 
-    return res.json()
+    if (!res.ok) {
+      console.log(res.status, res.statusText)
+      throw new Error("Failed to fetch Ethereum stablecoins data")
+    }
+
+    return await res.json()
   } catch (error) {
     // In production mode, throw an error to stop the build in case this fetch fails
     console.error(error)


### PR DESCRIPTION
At the moment, we have a lot of data fetching calls failing in our builds (error `429 Too Many Requests`).

## Description

This PR adds
1. Better logs to understand better why a fetch failed
2. Changed the `LIMIT_CPU` env variable to be `LIMIT_CPUS`. It is now a `number` in order to control the cpus we want to use per env.

## Context

By reducing the number of CPUs used, we reduce the number of parallel threads created at build time. This also means that each page will only be called the same number of threads that exist.

For example, if we have 2 CPUs, Next will try to build the project using 2 threads (better performance) but will also call `getStaticProps` 2 times and this is the problem we have at the moment.

Limiting `LIMIT_CPUS` to `1` will ensure that we only call `getStaticProps` once.

Not ideal ofc because we are losing performance but should only be used on prod and preview deploys envs. We need to find better ways to fail when we are in dev envs for better DX.