### PR TITLE
Redirect /en to /

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,5 @@
+/en/ / 301!
+
 /discord https://discord.gg/ethereum-org 301!
 
 /*/discord https://discord.gg/ethereum-org 301!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently `/en` does show the 404 page. This PR adds a redirect rule from `/en` to `/`.