### PR TITLE
HubHero layout shifting

### DIFF
--- a/src/components/Hero/HubHero/index.tsx
+++ b/src/components/Hero/HubHero/index.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Heading,
-  HStack,
-  Stack,
-  Text,
-  useBreakpointValue,
-} from "@chakra-ui/react"
+import { Box, Heading, HStack, Stack, Text } from "@chakra-ui/react"
 
 import type { CommonHeroProps } from "@/lib/types"
 
@@ -21,14 +14,6 @@ const HubHero = (props: CommonHeroProps) => {
     )
   }
 
-  const height = useBreakpointValue({
-    base: "192px",
-    md: "256px",
-    lg: "320px",
-    xl: "576px",
-    "2xl": "672px",
-  })
-
   return (
     <Box position="relative">
       <Image
@@ -36,7 +21,14 @@ const HubHero = (props: CommonHeroProps) => {
         alt=""
         priority
         sizes="100vw"
-        style={{ width: "100vw", objectFit: "cover", height }}
+        style={{ width: "100vw", objectFit: "cover" }}
+        h={{
+          base: "192px",
+          md: "256px",
+          lg: "320px",
+          xl: "576px",
+          "2xl": "672px",
+        }}
       />
       <Stack
         spacing={{ base: "3", md: "4" }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Sets the height using the Chakra style prop to prevent the layout from shifting on loading.
