### PR TITLE
Fix md image dimensions

### DIFF
--- a/src/components/MarkdownImage.tsx
+++ b/src/components/MarkdownImage.tsx
@@ -37,7 +37,7 @@ const MarkdownImage = ({
   }
 
   const fileExt = extname(transformedSrc).toLowerCase()
-  const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)  
+  const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)
 
   return (
     // display the wrapper as a `span` to avoid dom nesting warnings as mdx
@@ -51,6 +51,7 @@ const MarkdownImage = ({
           loading="lazy"
           src={transformedSrc}
           unoptimized={isAnimated}
+          h="auto"
           {...rest}
         />
       </Link>


### PR DESCRIPTION
Currently, we are setting the `height` of the image, but since this is also a Chakra style prop, some values may also represent Chakra sizes, as in this example:

We set `64`px for the image, but since `64` is also a Chakra size value, Chakra sets the css style with this value instead.
![image](https://github.com/ethereum/ethereum-org-fork/assets/468158/46496aea-d7aa-4650-80a7-f8c552d5dfeb)

## Description

This PR overrides the chakra height value by passing `auto`.