### PR TITLE
fix: translated images link

### DIFF
--- a/src/components/MarkdownImage.tsx
+++ b/src/components/MarkdownImage.tsx
@@ -37,13 +37,13 @@ const MarkdownImage = ({
   }
 
   const fileExt = extname(transformedSrc).toLowerCase()
-  const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)  
+  const isAnimated = [".gif", ".apng", ".webp"].includes(fileExt)
 
   return (
     // display the wrapper as a `span` to avoid dom nesting warnings as mdx
     // sometimes wraps images in `p` tags
     <Flex as="span" justify="center">
-      <Link href={transformedSrc} target="_blank" rel="noopener">
+      <Link href={transformedSrc} target="_blank" rel="noopener" locale={false}>
         <Image
           alt={alt}
           width={imageWidth}


### PR DESCRIPTION
Fixes `Link` path for translated images by disabling automatically preprended `locale`. This is currently causing issues for `MarkdownImage` and is not needed as we're already getting the `locale` from the image path in `getTranslatedImgPath`

Issue: https://www.notion.so/efdn/BUG-clicking-on-translated-images-fails-aea3e22c7ea94d68ae50fc084911a3d4?pvs=4