### PR TITLE
Events order and fetching fix

### DIFF
--- a/src/lib/api/calendarEvents.ts
+++ b/src/lib/api/calendarEvents.ts
@@ -11,7 +11,7 @@ export async function fetchCommunityEvents(): Promise<CommunityEventsReturnType>
 
   try {
     const futureEventsReq = await fetch(
-      `https://content.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${apiKey}&timeMin=${new Date().toISOString()}&singleEvents=true&orderby=starttime`
+      `https://content.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${apiKey}&timeMin=${new Date().toISOString()}&maxResults=3&singleEvents=true&orderby=starttime`
     )
     const futureEvents = await futureEventsReq.json()
     const futureEventsReqData: ReqCommunityEvent[] = futureEvents.items

--- a/src/lib/api/calendarEvents.ts
+++ b/src/lib/api/calendarEvents.ts
@@ -11,19 +11,20 @@ export async function fetchCommunityEvents(): Promise<CommunityEventsReturnType>
 
   try {
     const futureEventsReq = await fetch(
-      `https://content.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${apiKey}&timeMin=${new Date().toISOString()}&maxResults=3`
+      `https://content.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${apiKey}&timeMin=${new Date().toISOString()}&singleEvents=true&orderby=starttime`
     )
     const futureEvents = await futureEventsReq.json()
     const futureEventsReqData: ReqCommunityEvent[] = futureEvents.items
 
     const pastEventsReq = await fetch(
-      `https://content.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${apiKey}&timeMax=${new Date().toISOString()}&maxResults=4`
+      `https://content.googleapis.com/calendar/v3/calendars/${calendarId}/events?key=${apiKey}&timeMax=${new Date().toISOString()}&orderby=starttime`
     )
     const pastEvents = await pastEventsReq.json()
     const pastEventsReqData: ReqCommunityEvent[] = pastEvents.items
 
     const pastEventData = pastEventsReqData
       .filter((event) => event.start)
+      .slice(-4)
       .map((event) => {
         return {
           date: event.start.dateTime,
@@ -34,6 +35,7 @@ export async function fetchCommunityEvents(): Promise<CommunityEventsReturnType>
       })
     const upcomingEventData = futureEventsReqData
       .filter((event) => event.start)
+      .reverse()
       .map((event) => {
         return {
           date: event.start.dateTime,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixes missing params for fetching events
- Remove maxResults from pastEventsReq to get all past events, and slice this list to get last 4
- Reverses order of futureEventsReq to display properly
