### PR TITLE
cleanup: remove empty wrapper

### DIFF
--- a/src/pages/developers/tutorials.tsx
+++ b/src/pages/developers/tutorials.tsx
@@ -210,9 +210,6 @@ const TutorialPage = ({
           "page-developers-tutorials:page-tutorials-meta-description"
         )}
       />
-      <MainArticle>
-        
-      </MainArticle>
       <Heading
         fontStyle="normal"
         fontWeight="semibold"


### PR DESCRIPTION
This PR removes the empty `<MainArticle>` wrapper from `/developers/tutorials.tsx`, which is not needed as the main `Flex` is already being used as a `MainArticle` component