### PR TITLE
feat(Quiz): create reusable `QuizManager`

### DIFF
--- a/src/components/Quiz/QuizManager/index.tsx
+++ b/src/components/Quiz/QuizManager/index.tsx
@@ -1,0 +1,117 @@
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { FaGithub } from "react-icons/fa"
+import { Box, Flex, Icon, Stack, Text, useDisclosure } from "@chakra-ui/react"
+
+import { QuizStatus } from "@/lib/types"
+
+import { ButtonLink } from "@/components/Buttons"
+import Translation from "@/components/Translation"
+
+import { trackCustomEvent } from "@/lib/utils/matomo"
+
+import { ethereumBasicsQuizzes, usingEthereumQuizzes } from "@/data/quizzes"
+
+import { INITIAL_QUIZ } from "@/lib/constants"
+
+import QuizWidget from "../QuizWidget"
+import QuizzesList from "../QuizzesList"
+import QuizzesModal from "../QuizzesModal"
+import QuizzesStats from "../QuizzesStats"
+import { useLocalQuizData } from "../useLocalQuizData"
+
+const handleGHAdd = () =>
+  trackCustomEvent({
+    eventCategory: "quiz_hub_events",
+    eventAction: "Secondary button clicks",
+    eventName: "GH_add",
+  })
+
+const QuizManager = () => {
+  const { t } = useTranslation()
+
+  const [userStats, updateUserStats] = useLocalQuizData()
+  const [quizStatus, setQuizStatus] = useState<QuizStatus>("neutral")
+  const [currentQuiz, setCurrentQuiz] = useState(INITIAL_QUIZ)
+  const { onOpen, isOpen, onClose } = useDisclosure()
+
+  const commonQuizListProps = useMemo(
+    () => ({
+      userStats,
+      quizHandler: setCurrentQuiz,
+      modalHandler: onOpen,
+    }),
+    [onOpen, userStats]
+  )
+  return (
+    <>
+      <QuizzesModal isOpen={isOpen} onClose={onClose} quizStatus={quizStatus}>
+        <QuizWidget
+          quizKey={currentQuiz}
+          currentHandler={setCurrentQuiz}
+          statusHandler={setQuizStatus}
+          updateUserStats={updateUserStats}
+        />
+      </QuizzesModal>
+      <Box px={{ base: 0, lg: "8" }} py={{ base: 0, lg: "4" }} mb="12">
+        <Flex direction={{ base: "column-reverse", lg: "row" }} columnGap="20">
+          <Stack spacing="10" flex="1">
+            <Box>
+              <QuizzesList
+                content={ethereumBasicsQuizzes}
+                headingId={t("learn-quizzes:basics")}
+                descriptionId={t("learn-quizzes:basics-description")}
+                {...commonQuizListProps}
+              />
+              <QuizzesList
+                content={usingEthereumQuizzes}
+                headingId={t("learn-quizzes:using-ethereum")}
+                descriptionId={t("learn-quizzes:using-ethereum-description")}
+                {...commonQuizListProps}
+              />
+            </Box>
+            <Flex
+              direction={{ base: "column", xl: "row" }}
+              justify="space-between"
+              align="center"
+              bg="background.highlight"
+              borderRadius={{ lg: "lg" }}
+              p="8"
+              gap={{ base: "4", xl: 0 }}
+            >
+              <Box>
+                <Text align={{ base: "center", xl: "left" }} fontWeight="bold">
+                  <Translation id="learn-quizzes:want-more-quizzes" />
+                </Text>
+
+                <Text align={{ base: "center", xl: "left" }}>
+                  <Translation id="learn-quizzes:contribute" />
+                </Text>
+              </Box>
+              <ButtonLink
+                href="/contributing/quizzes/"
+                variant="outline"
+                hideArrow
+                onClick={handleGHAdd}
+              >
+                <Flex alignItems="center">
+                  <Icon as={FaGithub} color="text" boxSize={6} me={2} />
+                  <Translation id="learn-quizzes:add-quiz" />
+                </Flex>
+              </ButtonLink>
+            </Flex>
+          </Stack>
+          <Box flex="1">
+            <QuizzesStats
+              averageScoresArray={userStats.average}
+              completedQuizzes={userStats.completed}
+              totalCorrectAnswers={userStats.score}
+            />
+          </Box>
+        </Flex>
+      </Box>
+    </>
+  )
+}
+
+export default QuizManager

--- a/src/components/Quiz/QuizzesList/QuizItem.tsx
+++ b/src/components/Quiz/QuizzesList/QuizItem.tsx
@@ -3,10 +3,10 @@ import { Box, Flex, ListItem, Stack, Text } from "@chakra-ui/react"
 
 import type { QuizzesSection } from "@/lib/types"
 
-import { Button } from "../Buttons"
-import { GreenTickIcon } from "../icons/quiz"
-import Tag from "../Tag"
-import Translation from "../Translation"
+import { Button } from "../../Buttons"
+import { GreenTickIcon } from "../../icons/quiz"
+import Tag from "../../Tag"
+import Translation from "../../Translation"
 
 export type QuizzesListItemProps = Omit<QuizzesSection, "id"> & {
   isCompleted: boolean

--- a/src/components/Quiz/QuizzesList/index.tsx
+++ b/src/components/Quiz/QuizzesList/index.tsx
@@ -7,7 +7,7 @@ import { trackCustomEvent } from "@/lib/utils/matomo"
 
 import allQuizzesData from "@/data/quizzes"
 
-import Translation from "../Translation"
+import Translation from "../../Translation"
 
 import QuizItem from "./QuizItem"
 

--- a/src/components/Quiz/useLocalQuizData.ts
+++ b/src/components/Quiz/useLocalQuizData.ts
@@ -1,31 +1,36 @@
 import { CompletedQuizzes, UserStats } from "@/lib/types"
-
-import allQuizzesData from "@/data/quizzes"
-
-import { USER_STATS_KEY } from "@/lib/constants"
+import { RawQuizzes } from "@/lib/interfaces"
 
 import { useLocalStorage } from "@/hooks/useLocalStorage"
 
-/**
- * Contains each quiz id as key and <boolean, number> to indicate if its completed and the highest score in that quiz
- *
- * Initialize all quizzes as not completed
- */
-const INITIAL_COMPLETED_QUIZZES: CompletedQuizzes = Object.keys(
-  allQuizzesData
-).reduce((object, key) => ({ ...object, [key]: [false, 0] }), {})
-
-export const INITIAL_USER_STATS: UserStats = {
-  score: 0,
-  average: [],
-  completed: INITIAL_COMPLETED_QUIZZES,
+type UseLocalQuizDataProps = {
+  userStatsKey: string
+  allQuizData: RawQuizzes
 }
 
-export const useLocalQuizData = () => {
-  const data = useLocalStorage(
-    USER_STATS_KEY,
-    INITIAL_USER_STATS
+export const useLocalQuizData = ({
+  userStatsKey,
+  allQuizData,
+}: UseLocalQuizDataProps) => {
+  /**
+   * Contains each quiz id as key and <boolean, number> to indicate if its completed and the highest score in that quiz
+   *
+   * Initialize all quizzes as not completed
+   */
+  const INITIAL_COMPLETED_QUIZZES = Object.keys(
+    allQuizData
+  ).reduce<CompletedQuizzes>(
+    (object, key) => ({ ...object, [key]: [false, 0] }),
+    {}
   )
+
+  const INITIAL_USER_STATS: UserStats = {
+    score: 0,
+    average: [],
+    completed: INITIAL_COMPLETED_QUIZZES,
+  }
+
+  const data = useLocalStorage(userStatsKey, INITIAL_USER_STATS)
 
   return data
 }

--- a/src/pages/quizzes.tsx
+++ b/src/pages/quizzes.tsx
@@ -13,8 +13,12 @@ import QuizManager from "@/components/Quiz/QuizManager"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
-import { trackCustomEvent } from "@/lib/utils/matomo"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
+
+import allQuizzesData, {
+  ethereumBasicsQuizzes,
+  usingEthereumQuizzes,
+} from "@/data/quizzes"
 
 import HeroImage from "@/public/heroes/quizzes-hub-hero.png"
 
@@ -51,7 +55,22 @@ const QuizzesHubPage: NextPage<
         header={t("learn-quizzes:test-your-knowledge")}
         heroImg={HeroImage}
       />
-      <QuizManager />
+      <QuizManager
+        userStatsKey="quizzes-stats"
+        allQuizData={allQuizzesData}
+        quizListSections={[
+          {
+            descriptionId: t("learn-quizzes:basics-description"),
+            headingId: t("learn-quizzes:basics"),
+            QuizMeta: ethereumBasicsQuizzes,
+          },
+          {
+            descriptionId: t("learn-quizzes:using-ethereum-description"),
+            headingId: t("learn-quizzes:using-ethereum"),
+            QuizMeta: usingEthereumQuizzes,
+          },
+        ]}
+      />
       <Box w="full" py="4" px="8">
         <FeedbackCard />Q
       </Box>

--- a/src/pages/quizzes.tsx
+++ b/src/pages/quizzes.tsx
@@ -1,41 +1,22 @@
-import { useMemo, useState } from "react"
 import { GetStaticProps, InferGetStaticPropsType, NextPage } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import { FaGithub } from "react-icons/fa"
-import { Box, Flex, Icon, Stack, Text, useDisclosure } from "@chakra-ui/react"
+import { Box } from "@chakra-ui/react"
 
-import { BasePageProps, QuizStatus } from "@/lib/types"
+import { BasePageProps } from "@/lib/types"
 
-import { ButtonLink } from "@/components/Buttons"
 import FeedbackCard from "@/components/FeedbackCard"
 import { HubHero } from "@/components/Hero"
 import MainArticle from "@/components/MainArticle"
 import PageMetadata from "@/components/PageMetadata"
-import QuizWidget from "@/components/Quiz/QuizWidget"
-import QuizzesList from "@/components/Quiz/QuizzesList"
-import QuizzesModal from "@/components/Quiz/QuizzesModal"
-import QuizzesStats from "@/components/Quiz/QuizzesStats"
-import { useLocalQuizData } from "@/components/Quiz/useLocalQuizData"
-import Translation from "@/components/Translation"
+import QuizManager from "@/components/Quiz/QuizManager"
 
 import { existsNamespace } from "@/lib/utils/existsNamespace"
 import { getLastDeployDate } from "@/lib/utils/getLastDeployDate"
 import { trackCustomEvent } from "@/lib/utils/matomo"
 import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 
-import { ethereumBasicsQuizzes, usingEthereumQuizzes } from "@/data/quizzes"
-
-import { INITIAL_QUIZ } from "@/lib/constants"
-
 import HeroImage from "@/public/heroes/quizzes-hub-hero.png"
-
-const handleGHAdd = () =>
-  trackCustomEvent({
-    eventCategory: "quiz_hub_events",
-    eventAction: "Secondary button clicks",
-    eventName: "GH_add",
-  })
 
 export const getStaticProps = (async ({ locale }) => {
   const requiredNamespaces = getRequiredNamespacesForPage("/quizzes")
@@ -58,20 +39,6 @@ const QuizzesHubPage: NextPage<
 > = () => {
   const { t } = useTranslation()
 
-  const [userStats, updateUserStats] = useLocalQuizData()
-  const [quizStatus, setQuizStatus] = useState<QuizStatus>("neutral")
-  const [currentQuiz, setCurrentQuiz] = useState(INITIAL_QUIZ)
-  const { onOpen, isOpen, onClose } = useDisclosure()
-
-  const commonQuizListProps = useMemo(
-    () => ({
-      userStats,
-      quizHandler: setCurrentQuiz,
-      modalHandler: onOpen,
-    }),
-    [onOpen, userStats]
-  )
-
   return (
     <Box as={MainArticle}>
       <PageMetadata
@@ -84,73 +51,9 @@ const QuizzesHubPage: NextPage<
         header={t("learn-quizzes:test-your-knowledge")}
         heroImg={HeroImage}
       />
-      <QuizzesModal isOpen={isOpen} onClose={onClose} quizStatus={quizStatus}>
-        <QuizWidget
-          quizKey={currentQuiz}
-          currentHandler={setCurrentQuiz}
-          statusHandler={setQuizStatus}
-          updateUserStats={updateUserStats}
-        />
-      </QuizzesModal>
-      <Box px={{ base: 0, lg: "8" }} py={{ base: 0, lg: "4" }} mb="12">
-        <Flex direction={{ base: "column-reverse", lg: "row" }} columnGap="20">
-          <Stack spacing="10" flex="1">
-            <Box>
-              <QuizzesList
-                content={ethereumBasicsQuizzes}
-                headingId={t("learn-quizzes:basics")}
-                descriptionId={t("learn-quizzes:basics-description")}
-                {...commonQuizListProps}
-              />
-              <QuizzesList
-                content={usingEthereumQuizzes}
-                headingId={t("learn-quizzes:using-ethereum")}
-                descriptionId={t("learn-quizzes:using-ethereum-description")}
-                {...commonQuizListProps}
-              />
-            </Box>
-            <Flex
-              direction={{ base: "column", xl: "row" }}
-              justify="space-between"
-              align="center"
-              bg="background.highlight"
-              borderRadius={{ lg: "lg" }}
-              p="8"
-              gap={{ base: "4", xl: 0 }}
-            >
-              <Box>
-                <Text align={{ base: "center", xl: "left" }} fontWeight="bold">
-                  <Translation id="learn-quizzes:want-more-quizzes" />
-                </Text>
-
-                <Text align={{ base: "center", xl: "left" }}>
-                  <Translation id="learn-quizzes:contribute" />
-                </Text>
-              </Box>
-              <ButtonLink
-                href="/contributing/quizzes/"
-                variant="outline"
-                hideArrow
-                onClick={handleGHAdd}
-              >
-                <Flex alignItems="center">
-                  <Icon as={FaGithub} color="text" boxSize={6} me={2} />
-                  <Translation id="learn-quizzes:add-quiz" />
-                </Flex>
-              </ButtonLink>
-            </Flex>
-          </Stack>
-          <Box flex="1">
-            <QuizzesStats
-              averageScoresArray={userStats.average}
-              completedQuizzes={userStats.completed}
-              totalCorrectAnswers={userStats.score}
-            />
-          </Box>
-        </Flex>
-      </Box>
+      <QuizManager />
       <Box w="full" py="4" px="8">
-        <FeedbackCard />
+        <FeedbackCard />Q
       </Box>
     </Box>
   )


### PR DESCRIPTION
Creates a reusable `QuizManager` component, containing `QuizModal`, `QuizWidget`, `QuizzesList`, and `QuizzesStats`.

Used for providing separate quiz sets for multiple pages outside of the Quiz Hub.