### PR TITLE
Fix image device size cap at 1504px

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,14 +6,14 @@ const LIMIT_CPUS = Number(process.env.LIMIT_CPUS || 2)
 
 const experimental = LIMIT_CPUS
   ? {
-      // This option could be enabled in the future when flagged as stable, to speed up builds
-      // (see https://nextjs.org/docs/pages/building-your-application/configuring/mdx#using-the-rust-based-mdx-compiler-experimental)
-      // mdxRs: true,
+    // This option could be enabled in the future when flagged as stable, to speed up builds
+    // (see https://nextjs.org/docs/pages/building-your-application/configuring/mdx#using-the-rust-based-mdx-compiler-experimental)
+    // mdxRs: true,
 
-      // Reduce the number of cpus and disable parallel threads in prod envs to consume less memory
-      workerThreads: false,
-      cpus: LIMIT_CPUS,
-    }
+    // Reduce the number of cpus and disable parallel threads in prod envs to consume less memory
+    workerThreads: false,
+    cpus: LIMIT_CPUS,
+  }
   : {}
 
 /** @type {import('next').NextConfig} */
@@ -35,7 +35,7 @@ module.exports = (phase, { defaultConfig }) => {
     },
     i18n,
     images: {
-      deviceSizes: [640, 750, 828, 1080, 1200, 1504],
+      deviceSizes: [640, 750, 828, 1080, 1200, 1504, 1920, 2048],
     },
   }
 

--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,9 @@ module.exports = (phase, { defaultConfig }) => {
       return config
     },
     i18n,
+    images: {
+      deviceSizes: [640, 750, 828, 1080, 1200, 1504],
+    },
   }
 
   if (phase !== PHASE_DEVELOPMENT_SERVER) {

--- a/next.config.js
+++ b/next.config.js
@@ -35,7 +35,7 @@ module.exports = (phase, { defaultConfig }) => {
     },
     i18n,
     images: {
-      deviceSizes: [640, 750, 828, 1080, 1200, 1504, 1920, 2048],
+      deviceSizes: [640, 750, 828, 1080, 1200, 1504, 1920],
     },
   }
 


### PR DESCRIPTION
## Description

Next.js docs: https://nextjs.org/docs/pages/api-reference/components/image#devicesizes

The default `deviceSizes` includes device sizes beyond the max width of 1504px that we use, causing images (especially heroes) to load a larger image than needed. Overriding the default `deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],` with `deviceSizes: [640, 750, 828, 1080, 1200, 1504],` brings the image sizes back down to what we're used to, if not better.

Example: Homepage hero -> Production 800 kB, Next.js dev preview 2.7 MB, locally with above changes 556 kB

This _does_ however reduce the quality of the image slightly... Our Next.js preview site currently has slightly sharper images than production, and the above change makes them look like they do in production again. I tried adding `quality={100}` to these images to see if that would help (since currently it's using a quality of 75), but it doesn't seem to change anything. The `type` seems to be what's doing it, as the above changes make them load as `webp` instead of `png` (which is parity with production)

## Changes

- Overrides default decideSizes for images, capping largest device size at 1504px (global website max width)
- Reduces image sizes which were coming in significantly larger than in previous Gatsby repo