### PR TITLE
[fix] locale path casing bugs

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -17,4 +17,10 @@ module.exports = {
   localePath: "./src/intl",
   // see updates to your translation JSON files without having to restart your development server each time
   reloadOnPrerender: true,
+  // Language codes to lookup, given set language is 'en-US': 'all' --> ['en-US', 'en', 'dev'], 'currentOnly' --> 'en-US', 'languageOnly' --> 'en'
+  load: "currentOnly",
+  // Language will be lowercased EN --> en while leaving full locales like en-US
+  cleanCode: true,
+  // Language will be lowercased eg. en-US --> en-us
+  lowerCaseLng: true,
 }


### PR DESCRIPTION
## Description

Adds config options to next-i18next.config.js to look for translation files using lowercase lang codes. Allows codes with region-specificity (i.e. pt-br, zh-tw, or hy-am) to be agnostic to capitalization of the region (i.e. pt-BR or pt-br will work in the URL)

## Related Issue
Alternative approach to #252, see https://github.com/ethereum/ethereum-org-fork/pull/252#pullrequestreview-1803234661