### PR TITLE
Patch CodeModal and TitleCardList

### DIFF
--- a/src/components/CodeModal.tsx
+++ b/src/components/CodeModal.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import type { ReactNode } from "react"
 import {
   Modal,
   ModalBody,
@@ -7,40 +7,33 @@ import {
   ModalHeader,
   ModalOverlay,
 } from "@chakra-ui/react"
-export interface IProps {
-  children?: React.ReactNode
+
+type CodeModalProps = {
+  title: string
+  children: ReactNode
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
-  title: string
 }
 
-const CodeModal: React.FC<IProps> = ({
-  children,
-  isOpen,
-  setIsOpen,
-  title,
-}) => {
-  return (
-    <Modal
-      isOpen={isOpen}
-      scrollBehavior="inside"
-      variant="code"
-      onClose={() => setIsOpen(false)}
-    >
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>{title}</ModalHeader>
-        <ModalCloseButton
-          style={{
-            right: "unset",
-            insetInlineEnd: "var(--eth-sizes-4)",
-          }}
-        />
-
-        <ModalBody>{children}</ModalBody>
-      </ModalContent>
-    </Modal>
-  )
-}
+const CodeModal = ({ children, isOpen, setIsOpen, title }: CodeModalProps) => (
+  <Modal
+    isOpen={isOpen}
+    scrollBehavior="inside"
+    variant="code"
+    onClose={() => setIsOpen(false)}
+  >
+    <ModalOverlay />
+    <ModalContent>
+      <ModalHeader>{title}</ModalHeader>
+      <ModalCloseButton
+        style={{
+          right: "unset",
+          insetInlineEnd: "var(--eth-sizes-4)",
+        }}
+      />
+      <ModalBody>{children}</ModalBody>
+    </ModalContent>
+  </Modal>
+)
 
 export default CodeModal

--- a/src/components/CodeModal.tsx
+++ b/src/components/CodeModal.tsx
@@ -30,7 +30,12 @@ const CodeModal: React.FC<IProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{title}</ModalHeader>
-        <ModalCloseButton />
+        <ModalCloseButton
+          style={{
+            right: "unset",
+            insetInlineEnd: "var(--eth-sizes-4)",
+          }}
+        />
 
         <ModalBody>{children}</ModalBody>
       </ModalContent>

--- a/src/components/TitleCardList.tsx
+++ b/src/components/TitleCardList.tsx
@@ -65,12 +65,7 @@ const TitleCardList: React.FC<IProps> = ({
         borderBottomStyle="solid"
         borderBottomColor="text"
       >
-        <Icon
-          as={IoCodeOutline}
-          _hover={{
-            path: { fill: "tranparent" },
-          }}
-        />
+        <Icon as={IoCodeOutline} />
         <Translation id={headerKey} />
         {isCode && (
           <Hide below="s">
@@ -154,12 +149,7 @@ const TitleCardList: React.FC<IProps> = ({
               </Box>
             </Flex>
             {caption && (
-              <Flex
-                flex="1 0 25%"
-                alignItems="center"
-                flexWrap="wrap"
-                me={4}
-              >
+              <Flex flex="1 0 25%" alignItems="center" flexWrap="wrap" me={4}>
                 <Box
                   fontSize="sm"
                   marginBottom="0"
@@ -185,7 +175,7 @@ const TitleCardList: React.FC<IProps> = ({
             _hover={{
               boxShadow: "0 0 1px var(--eth-colors-primary-base)",
               bg: "primary100",
-              color: "black",
+              "*": { color: "black" },
             }}
           >
             {image && (
@@ -209,12 +199,7 @@ const TitleCardList: React.FC<IProps> = ({
               </Box>
             </Flex>
             {caption && (
-              <Flex
-                flex="1 0 25%"
-                alignItems="center"
-                flexWrap="wrap"
-                me={4}
-              >
+              <Flex flex="1 0 25%" alignItems="center" flexWrap="wrap" me={4}>
                 <Box
                   fontSize="sm"
                   marginBottom="0"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -513,7 +513,7 @@ const HomePage = ({
               borderColor="text"
               boxShadow={cardBoxShadow}
               maxWidth={{ lg: "624px" }}
-              ml={{ lg: 16 }}
+              ms={{ lg: 16 }}
             />
           </Box>
           <FeatureContent>


### PR DESCRIPTION
## Description
- Overrides `ModalCloseButton` styling to force direction-responsive absolute positioning using `insetInlineEnd` instead of default `right`... fixes overlapping text on RTL locales
- Patches use of `ml` with `ms` for code example list positioning on desktop
- Fixes text color on hover for code example items using dark mode
- Refactors `CodeModal` using latest code conventions

## Related Issue
Close button on code example modal (homepage) was overlapping with label for RTL langs:
<img width="1022" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/cbd4a093-57d6-48db-8877-a02cb414bfbe">

Contrast ratio was un-readable when hovering code example options in dark mode, and right margin incorrect:
<img width="1512" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/23dd87c9-9011-4fbe-83aa-a34d7e96c1e4">

**With fixes:**
<img width="1512" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/39ec15f5-b1f8-4147-8e4b-d8bc5dcf3e1f">

<img width="1024" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/d1ce3bd7-5fbe-4a11-90ea-911734a46dbf">

<img width="1019" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/52c1e83d-d784-4d61-9eff-f9ee9a6ef5e6">
