### PR TITLE
Redirect `/en/stablecoins` to `/stablecoins`

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -179,3 +179,5 @@
 /studio /en/deprecated-software/#ethereum-studio 301!
 
 /*/studio /:splat/deprecated-software/#ethereum-studio 301!
+
+/en/stablecoins /stablecoins 301!


### PR DESCRIPTION
## Description

Currently, `/en/stablecoins` throws a 404. Since we couldn't find the root problem, we are adding a redirect to see if it works as a workaround.
