### PR TITLE
Fix: Use absolute path to check if intl namespace exists

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,6 +6,7 @@ export const OLD_CONTENT_DIR = "src/content"
 export const CONTENT_DIR = "public/content"
 export const TRANSLATIONS_DIR = "public/content/translations"
 export const TRANSLATED_IMAGES_DIR = "/content/translations"
+export const INTL_JSON_DIR = "src/intl"
 
 // i18n
 export const DEFAULT_LOCALE = "en"

--- a/src/lib/utils/existsNamespace.ts
+++ b/src/lib/utils/existsNamespace.ts
@@ -11,6 +11,6 @@ export const existsNamespace = (
   locale: string,
   namespace: string,
 ): boolean => {
-  const nsJsonPathForLocale = join("../intl", locale, namespace + ".json")
+  const nsJsonPathForLocale = join("src/intl", locale, namespace + ".json")
   return existsSync(nsJsonPathForLocale)
 }

--- a/src/lib/utils/existsNamespace.ts
+++ b/src/lib/utils/existsNamespace.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "fs"
 import { join } from "path"
 
+import { INTL_JSON_DIR } from "@/lib/constants"
+
 /**
  * Checks if a namespace .json file exists for the given locale
  * @param locale Path locale
@@ -11,6 +13,6 @@ export const existsNamespace = (
   locale: string,
   namespace: string,
 ): boolean => {
-  const nsJsonPathForLocale = join("src/intl", locale, namespace + ".json")
+  const nsJsonPathForLocale = join(INTL_JSON_DIR, locale, namespace + ".json")
   return existsSync(nsJsonPathForLocale)
 }

--- a/src/lib/utils/translations.ts
+++ b/src/lib/utils/translations.ts
@@ -44,49 +44,47 @@ export const getRequiredNamespacesForPage = (
 }
 
 const getRequiredNamespacesForPath = (path: string) => {
-  let requiredNamespaces: string[] = []
+  let primaryNamespace: string | undefined // the primary namespace for the page
+  let requiredNamespaces: string[] = [] // any additional namespaces required for the page
 
   if (path === "assets") {
-    requiredNamespaces = [...requiredNamespaces, "page-assets"]
+    primaryNamespace = "page-assets"
   }
 
   if (path === "/") {
-    requiredNamespaces = [...requiredNamespaces, "page-index"]
+    primaryNamespace = "page-index"
   }
 
   if (path === "/contributing/translation-program/acknowledgements") {
-    requiredNamespaces = [
-      ...requiredNamespaces,
-      "page-contributing-translation-program-acknowledgements",
-    ]
+    primaryNamespace = "page-contributing-translation-program-acknowledgements"
   }
 
   if (path === "/contributing/translation-program/contributors") {
+    primaryNamespace = "page-contributing-translation-program-contributors"
     requiredNamespaces = [
       ...requiredNamespaces,
-      "page-contributing-translation-program-contributors",
       "page-languages",
     ]
   }
 
   if (path.startsWith("/community")) {
-    requiredNamespaces = [...requiredNamespaces, "page-community"]
+    primaryNamespace = "page-community"
   }
 
   if (path.startsWith("/dapps")) {
-    requiredNamespaces = [...requiredNamespaces, "page-dapps"]
+    primaryNamespace = "page-dapps"
   }
 
   if (path.startsWith("/energy-consumption")) {
+    primaryNamespace = "page-what-is-ethereum"
     requiredNamespaces = [
       ...requiredNamespaces,
       "page-about",
-      "page-what-is-ethereum",
     ]
   }
 
   if (path.startsWith("/eth")) {
-    requiredNamespaces = [...requiredNamespaces, "page-eth"]
+    primaryNamespace = "page-eth"
   }
 
   if (path.startsWith("/glossary") || path.startsWith("/dapps")) {
@@ -94,48 +92,39 @@ const getRequiredNamespacesForPath = (path: string) => {
   }
 
   if (path.startsWith("/history")) {
-    requiredNamespaces = [...requiredNamespaces, "page-history"]
+    primaryNamespace = "page-history"
   }
 
   if (path.startsWith("/stablecoins")) {
-    requiredNamespaces = [...requiredNamespaces, "page-stablecoins"]
+    primaryNamespace = "page-stablecoins"
   }
 
   if (path.startsWith("/staking")) {
-    requiredNamespaces = [...requiredNamespaces, "page-staking"]
+    primaryNamespace = "page-staking"
   }
 
   if (path.startsWith("/staking/deposit-contract")) {
-    requiredNamespaces = [
-      ...requiredNamespaces,
-      "page-staking-deposit-contract",
-    ]
+    primaryNamespace = "page-staking-deposit-contract"
   }
 
   if (path.startsWith("/developers")) {
-    requiredNamespaces = [...requiredNamespaces, "page-developers-index"]
+    primaryNamespace = "page-developers-index"
   }
 
   if (path.startsWith("/learn")) {
-    requiredNamespaces = [...requiredNamespaces, "page-learn"]
+    primaryNamespace = "page-learn"
   }
 
   if (path.startsWith("/developers/local-environment")) {
-    requiredNamespaces = [
-      ...requiredNamespaces,
-      "page-developers-local-environment",
-    ]
+    primaryNamespace = "page-developers-local-environment"
   }
 
   if (path.startsWith("/developers/learning-tools")) {
-    requiredNamespaces = [
-      ...requiredNamespaces,
-      "page-developers-learning-tools",
-    ]
+    primaryNamespace = "page-developers-learning-tools"
   }
 
   if (path.startsWith("/developers/tutorials")) {
-    requiredNamespaces = [...requiredNamespaces, "page-developers-tutorials"]
+    primaryNamespace = "page-developers-tutorials"
   }
 
   if (path.startsWith("/developers/docs/scaling")) {
@@ -143,27 +132,28 @@ const getRequiredNamespacesForPath = (path: string) => {
   }
 
   if (path === "get-eth") {
-    requiredNamespaces = [...requiredNamespaces, "page-get-eth"]
+    primaryNamespace = "page-get-eth"
   }
 
   if (path.startsWith("/languages")) {
-    requiredNamespaces = [...requiredNamespaces, "page-languages"]
+    primaryNamespace = "page-languages"
   }
 
   if (path.startsWith("/roadmap/vision")) {
+    primaryNamespace = "page-roadmap-vision"
     requiredNamespaces = [
       ...requiredNamespaces,
-      "page-roadmap-vision",
       "page-upgrades-index",
     ]
   }
 
   if (path.startsWith("/gas")) {
-    requiredNamespaces = [...requiredNamespaces, "page-gas", "page-community"]
+    primaryNamespace = "page-gas"
+    requiredNamespaces = [...requiredNamespaces, "page-gas"]
   }
 
   if (path.startsWith("/what-is-ethereum")) {
-    requiredNamespaces = [...requiredNamespaces, "page-what-is-ethereum"]
+    primaryNamespace = "page-what-is-ethereum"
   }
 
   // Quizzes
@@ -183,30 +173,32 @@ const getRequiredNamespacesForPath = (path: string) => {
   }
 
   if (path === "bug-bounty") {
-    requiredNamespaces = [...requiredNamespaces, "page-bug-bounty"]
+    primaryNamespace = "page-bug-bounty"
   }
 
   if (path === "run-a-node") {
-    requiredNamespaces = [...requiredNamespaces, "page-run-a-node"]
+    primaryNamespace = "page-run-a-node"
   }
 
   if (path.startsWith("/wallets")) {
-    requiredNamespaces = [...requiredNamespaces, "page-wallets", "glossary"]
+    primaryNamespace = "page-wallets"
+    requiredNamespaces = [...requiredNamespaces, "glossary"]
   }
 
   if (path.startsWith("/wallets/find-wallet")) {
+    primaryNamespace = "page-wallets-find-wallet"
     requiredNamespaces = [
       ...requiredNamespaces,
       "page-wallets",
-      "page-wallets-find-wallet",
     ]
   }
 
   if (path.startsWith("/layer-2")) {
-    requiredNamespaces = [...requiredNamespaces, "page-layer-2"]
+    primaryNamespace = "page-layer-2"
   }
 
-  return requiredNamespaces
+  // Ensures that the primary namespace is always the first item in the array
+  return primaryNamespace ? [primaryNamespace, ...requiredNamespaces] : [...requiredNamespaces]
 }
 
 const getRequiredNamespacesForLayout = (layout?: string) => {

--- a/src/lib/utils/translations.ts
+++ b/src/lib/utils/translations.ts
@@ -156,22 +156,6 @@ const getRequiredNamespacesForPath = (path: string) => {
     primaryNamespace = "page-what-is-ethereum"
   }
 
-  // Quizzes
-  // Note: Add any URL paths that have quizzes here
-  if (
-    path.startsWith("/eth") ||
-    path.startsWith("/layer-2") ||
-    path.startsWith("/nft") ||
-    path.startsWith("/roadmap/merge") ||
-    path.startsWith("/security") ||
-    path.startsWith("/wallets") ||
-    path.startsWith("/web3") ||
-    path.startsWith("/what-is-ethereum") ||
-    path.startsWith("/quizzes")
-  ) {
-    requiredNamespaces = [...requiredNamespaces, "learn-quizzes"]
-  }
-
   if (path === "bug-bounty") {
     primaryNamespace = "page-bug-bounty"
   }
@@ -195,6 +179,22 @@ const getRequiredNamespacesForPath = (path: string) => {
 
   if (path.startsWith("/layer-2")) {
     primaryNamespace = "page-layer-2"
+  }
+
+  // Quizzes
+  // Note: Add any URL paths that have quizzes here
+  if (
+    path.startsWith("/eth") ||
+    path.startsWith("/layer-2") ||
+    path.startsWith("/nft") ||
+    path.startsWith("/roadmap/merge") ||
+    path.startsWith("/security") ||
+    path.startsWith("/wallets") ||
+    path.startsWith("/web3") ||
+    path.startsWith("/what-is-ethereum") ||
+    path.startsWith("/quizzes")
+  ) {
+    requiredNamespaces = [...requiredNamespaces, "learn-quizzes"]
   }
 
   // Ensures that the primary namespace is always the first item in the array

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -15,6 +15,7 @@ import { getRequiredNamespacesForPage } from "@/lib/utils/translations"
 export const getStaticProps = (async ({ locale }) => {
   const requiredNamespaces = getRequiredNamespacesForPage("/")
 
+  // Want to check common namespace, so looking at requiredNamespaces[0]
   const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[0])
 
   const lastDeployDate = getLastDeployDate()

--- a/src/pages/developers/learning-tools.tsx
+++ b/src/pages/developers/learning-tools.tsx
@@ -122,7 +122,7 @@ export const getStaticProps = (async ({ locale }) => {
     "/developers/learning-tools"
   )
 
-  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
+  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[1])
 
   const lastDeployDate = getLastDeployDate()
 

--- a/src/pages/developers/local-environment.tsx
+++ b/src/pages/developers/local-environment.tsx
@@ -65,7 +65,7 @@ export const getStaticProps = (async ({ locale }) => {
     "/developers/local-environment"
   )
 
-  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
+  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[1])
 
   const frameworksListData = await cachedFetchLocalEnvironmentFrameworkData()
 

--- a/src/pages/developers/tutorials.tsx
+++ b/src/pages/developers/tutorials.tsx
@@ -82,7 +82,7 @@ export const getStaticProps = (async ({ locale }) => {
     "/developers/tutorials"
   )
 
-  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
+  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[1])
 
   const lastDeployDate = getLastDeployDate()
 

--- a/src/pages/layer-2.tsx
+++ b/src/pages/layer-2.tsx
@@ -115,7 +115,7 @@ export const getStaticProps = (async ({ locale }) => {
 
   const requiredNamespaces = getRequiredNamespacesForPage("/layer-2")
 
-  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
+  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[1])
 
   return {
     props: {

--- a/src/pages/staking/deposit-contract.tsx
+++ b/src/pages/staking/deposit-contract.tsx
@@ -214,7 +214,7 @@ export const getStaticProps = (async ({ locale }) => {
     "/staking/deposit-contract"
   )
 
-  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
+  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[1])
 
   const lastDeployDate = getLastDeployDate()
 

--- a/src/pages/wallets/find-wallet.tsx
+++ b/src/pages/wallets/find-wallet.tsx
@@ -95,7 +95,7 @@ export const getStaticProps = (async ({ locale }) => {
     "/wallets/find-wallet"
   )
 
-  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[3])
+  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[1])
 
   return {
     props: {

--- a/src/pages/wallets/index.tsx
+++ b/src/pages/wallets/index.tsx
@@ -133,7 +133,7 @@ export const getStaticProps = (async ({ locale }) => {
 
   const requiredNamespaces = getRequiredNamespacesForPage("/wallets")
 
-  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[2])
+  const contentNotTranslated = !existsNamespace(locale!, requiredNamespaces[1])
 
   return {
     props: {


### PR DESCRIPTION
## Description
Use absolute path to check if intl namespace exists to fix banner logic

## Related Issue
<img width="1626" alt="image" src="https://github.com/ethereum/ethereum-org-fork/assets/54227730/b24eb98f-46c9-4ff5-9351-1b2809135cf8">
"Page in English" banner was showing up for pages where the content was already translated