### PR TITLE
adjust roadmap header image height to match production

### DIFF
--- a/src/layouts/Roadmap.tsx
+++ b/src/layouts/Roadmap.tsx
@@ -181,7 +181,7 @@ export const RoadmapLayout: React.FC<IProps> = ({
               alt={frontmatter.alt ?? ""}
               style={{ objectFit: "contain" }}
               width={1504}
-              height={345}
+              height={336}
               priority
             />
           </Center>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adjusts height of image to fix padding and size issues

**Note**: The image is wider than production, not sure if this has to do with no longer stretching image like Gatsby. I think this looks better, but would be curious your thoughts @nloureiro 
